### PR TITLE
Update README.md with instructions to download

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ Safety is a feature that ExcalidrawZ highly prioritize as a local client. To ens
 
 ![File History](https://github.com/chocoford/ExcalidrawZ/assets/28218759/b4feb7df-4278-4a5c-8c78-c83200efc99b)
 
+#### Steps to Install 
+
+1. Download the latest image file (.dmg) from ![Releases](https://github.com/chocoford/ExcalidrawZ/releases)
+2. Click the `.dmg` to install it
+
 ## RoadMap
 
 - [ ] iCloud synchronization


### PR DESCRIPTION
[Problem]
README.md lacks clear download instructions. It would be hard for non-frequent github users to navigate to 'Releases' tab to fetch the assets.

[Solution]
Fixed README.md with instructions to download and install