### PR TITLE
Sync Excalidraw MCP create_view metadata

### DIFF
--- a/ExcalidrawZ/Utils/MCP/UpstreamCompat/ExcalidrawMCPUpstreamToolHandler.swift
+++ b/ExcalidrawZ/Utils/MCP/UpstreamCompat/ExcalidrawMCPUpstreamToolHandler.swift
@@ -12,6 +12,11 @@ struct ExcalidrawMCPUpstreamToolHandler {
         let checkpointID: String
     }
 
+    private struct CameraSize: Sendable {
+        let width: Double
+        let height: Double
+    }
+
     typealias ElementConverter = @Sendable ([MCPJSONValue]) async throws -> [MCPJSONValue]
     typealias PublishDiagram = @Sendable (
         _ elements: [MCPJSONValue],
@@ -85,6 +90,7 @@ struct ExcalidrawMCPUpstreamToolHandler {
         }
 
         let convertedElements = try await convertRawElements(resolved.elements)
+        let ratioHint = Self.cameraAspectRatioHint(from: parsedElements)
         let published = try await publishDiagram(
             convertedElements,
             parsedElements.count,
@@ -94,7 +100,7 @@ struct ExcalidrawMCPUpstreamToolHandler {
         return ExcalidrawMCPToolResult(
             text: """
             Diagram received by ExcalidrawZ and applied to a file. Checkpoint id: "\(published.checkpointID)".
-            If the user asks to revise this diagram, call create_view again with a restoreCheckpoint pseudo-element using that id.
+            If the user asks to revise this diagram, call create_view again with a restoreCheckpoint pseudo-element using that id.\(ratioHint)
             """,
             structuredContent: .object([
                 "checkpointId": .string(published.checkpointID)
@@ -146,5 +152,47 @@ struct ExcalidrawMCPUpstreamToolHandler {
         let jsonData = try data.mcpJSONData()
         let json = String(data: jsonData, encoding: .utf8) ?? "[]"
         return ExcalidrawMCPToolResult(text: json)
+    }
+
+    private static func cameraAspectRatioHint(from elements: [MCPJSONValue]) -> String {
+        guard let camera = elements.compactMap(cameraSize(from:)).first(where: { camera in
+            abs((camera.width / camera.height) - (4.0 / 3.0)) > 0.15
+        }) else {
+            return ""
+        }
+
+        return "\nTip: your cameraUpdate used \(displayNumber(camera.width))x\(displayNumber(camera.height)) — try to stick with 4:3 aspect ratio (e.g. 400x300, 800x600) in future."
+    }
+
+    private static func cameraSize(from element: MCPJSONValue) -> CameraSize? {
+        guard element["type"]?.stringValue == ExcalidrawMCPUpstreamContract.PseudoElementType.cameraUpdate,
+              let width = finiteNumber(element["width"]),
+              let height = finiteNumber(element["height"]),
+              width > 0,
+              height > 0
+        else {
+            return nil
+        }
+
+        return CameraSize(width: width, height: height)
+    }
+
+    private static func finiteNumber(_ value: MCPJSONValue?) -> Double? {
+        switch value {
+            case .number(let number) where number.isFinite:
+                return number
+            case .string(let string):
+                let number = Double(string.trimmingCharacters(in: .whitespacesAndNewlines))
+                return number?.isFinite == true ? number : nil
+            default:
+                return nil
+        }
+    }
+
+    private static func displayNumber(_ number: Double) -> String {
+        if number.rounded(.towardZero) == number {
+            return String(Int(number))
+        }
+        return String(number)
     }
 }

--- a/ExcalidrawZ/Utils/MCP/UpstreamCompat/ExcalidrawMCPUpstreamTools.swift
+++ b/ExcalidrawZ/Utils/MCP/UpstreamCompat/ExcalidrawMCPUpstreamTools.swift
@@ -210,7 +210,8 @@ enum ExcalidrawMCPUpstreamToolCatalog {
             name: ExcalidrawMCPUpstreamContract.ToolName.createView,
             title: "Draw Diagram",
             description: "Renders a hand-drawn diagram using Excalidraw elements. Elements stream in one by one with draw-on animations. Call read_me first to learn the element format.",
-            inputSchema: ExcalidrawMCPToolSchemas.createView
+            inputSchema: ExcalidrawMCPToolSchemas.createView,
+            annotations: ["readOnlyHint": .bool(true)]
         ),
         ExcalidrawMCPTool(
             name: ExcalidrawMCPUpstreamContract.ToolName.saveCheckpoint,


### PR DESCRIPTION
Syncs upstream `create_view` read-only metadata and the 4:3 camera result hint. Leaves MCP Apps widget/runtime details and ExcalidrawZ host transport/lifecycle/file/canvas/storage/UI behavior outside `UpstreamCompat`.

Validation: `git diff --check` and `xcrun swiftc -parse` for the two changed UpstreamCompat files.