### PR TITLE
[codex] Sync Excalidraw MCP checkpoint behavior

### DIFF
--- a/ExcalidrawZ/Utils/MCP/UpstreamCompat/ExcalidrawMCPUpstreamElementResolver.swift
+++ b/ExcalidrawZ/Utils/MCP/UpstreamCompat/ExcalidrawMCPUpstreamElementResolver.swift
@@ -11,7 +11,7 @@ struct ExcalidrawMCPCheckpointNotFoundError: LocalizedError, Sendable {
     let id: String
 
     var errorDescription: String? {
-        "Checkpoint \"\(id)\" not found. Use a checkpointId returned by create_view or save_checkpoint, or recreate the diagram from scratch."
+        "Checkpoint \"\(id)\" not found — it may have expired or never existed.\nPlease recreate the diagram from scratch."
     }
 }
 
@@ -74,7 +74,7 @@ struct ExcalidrawMCPUpstreamElementResolver {
                     viewportUpdate = Self.viewportUpdate(from: element) ?? viewportUpdate
                     continue
                 case ExcalidrawMCPUpstreamContract.PseudoElementType.restoreCheckpoint:
-                    restoreCheckpointID = element["id"]?.stringValue
+                    restoreCheckpointID = Self.nonEmptyString(element["id"])
                 case ExcalidrawMCPUpstreamContract.PseudoElementType.delete:
                     deleteIDs.formUnion(Self.deleteIDs(from: element))
                 default:
@@ -83,7 +83,9 @@ struct ExcalidrawMCPUpstreamElementResolver {
         }
 
         if !deleteIDs.isEmpty {
-            drawElements = Self.filterDeletedElements(drawElements, deleteIDs: deleteIDs)
+            drawElements = drawElements.map {
+                Self.elementHiddenForInlineDelete($0, deleteIDs: deleteIDs)
+            }
         }
 
         return ExtractedElements(
@@ -144,20 +146,55 @@ struct ExcalidrawMCPUpstreamElementResolver {
         return deleteIDs.contains(id ?? "") || deleteIDs.contains(containerID ?? "")
     }
 
+    private static func elementHiddenForInlineDelete(
+        _ element: MCPJSONValue,
+        deleteIDs: Set<String>
+    ) -> MCPJSONValue {
+        guard shouldHideInlineDeletedElement(element, deleteIDs: deleteIDs),
+              var object = element.objectValue
+        else {
+            return element
+        }
+
+        // Upstream uses opacity 1, not 0, because Excalidraw treats 0 as unset.
+        object["opacity"] = .number(1)
+        return .object(object)
+    }
+
     private static func deleteIDs(from element: MCPJSONValue) -> [String] {
         guard element["type"]?.stringValue == ExcalidrawMCPUpstreamContract.PseudoElementType.delete else {
             return []
         }
         if let ids = element["ids"]?.arrayValue {
-            return ids.compactMap(\.stringValue)
+            return ids.compactMap(Self.stringLikeValue)
                 .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
                 .filter { !$0.isEmpty }
         }
 
-        let raw = element["ids"]?.stringValue ?? element["id"]?.stringValue ?? ""
+        let raw = Self.stringLikeValue(element["ids"]) ?? Self.stringLikeValue(element["id"]) ?? ""
         return raw
             .split(separator: ",")
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
+    }
+
+    private static func stringLikeValue(_ value: MCPJSONValue?) -> String? {
+        switch value {
+            case .string(let string):
+                return string
+            case .number(let number) where number.isFinite:
+                return number.rounded(.towardZero) == number
+                    ? String(Int(number))
+                    : String(number)
+            default:
+                return nil
+        }
+    }
+
+    private static func nonEmptyString(_ value: MCPJSONValue?) -> String? {
+        guard let string = value?.stringValue, !string.isEmpty else {
+            return nil
+        }
+        return string
     }
 }

--- a/ExcalidrawZ/Utils/MCP/UpstreamCompat/ExcalidrawMCPUpstreamToolHandler.swift
+++ b/ExcalidrawZ/Utils/MCP/UpstreamCompat/ExcalidrawMCPUpstreamToolHandler.swift
@@ -71,7 +71,7 @@ struct ExcalidrawMCPUpstreamToolHandler {
             parsedElements = try MCPJSONValue.parseJSONArray(from: inputData)
         } catch {
             return ExcalidrawMCPToolResult(
-                text: "Invalid JSON in elements. Ensure the value is a JSON array string with no comments or trailing commas.",
+                text: "Invalid JSON in elements: \(error.localizedDescription).\nEnsure no comments, no trailing commas, and proper quoting.",
                 isError: true
             )
         }
@@ -99,8 +99,8 @@ struct ExcalidrawMCPUpstreamToolHandler {
 
         return ExcalidrawMCPToolResult(
             text: """
-            Diagram received by ExcalidrawZ and applied to a file. Checkpoint id: "\(published.checkpointID)".
-            If the user asks to revise this diagram, call create_view again with a restoreCheckpoint pseudo-element using that id.\(ratioHint)
+            Diagram displayed! Checkpoint id: "\(published.checkpointID)". If user asks to create a new diagram - simply create a new one from scratch.
+            However, if the user wants to edit something on this diagram "\(published.checkpointID)", use this one as starting checkpoint: simply start from the first element [{"type":"restoreCheckpoint","id":"\(published.checkpointID)"}, ...your new elements...] this will use same diagram state as the user currently sees, including any manual edits captured by the app, allowing you to add elements on top. To remove elements, use: {"type":"delete","ids":","}\(ratioHint)
             """,
             structuredContent: .object([
                 "checkpointId": .string(published.checkpointID)
@@ -143,10 +143,7 @@ struct ExcalidrawMCPUpstreamToolHandler {
             throw MCPJSONRPCError.invalidParams("read_checkpoint requires arguments.id.")
         }
         guard let data = await readCheckpointData(id) else {
-            return ExcalidrawMCPToolResult(
-                text: ExcalidrawMCPCheckpointNotFoundError(id: id).localizedDescription,
-                isError: true
-            )
+            return ExcalidrawMCPToolResult(text: "")
         }
 
         let jsonData = try data.mcpJSONData()


### PR DESCRIPTION
## Summary

Sync the ExcalidrawZ MCP upstream compatibility layer with current `excalidraw/excalidraw-mcp@main` checkpoint-facing behavior:

- Return upstream-style `create_view` checkpoint guidance and invalid JSON errors while keeping ExcalidrawZ file creation outside UpstreamCompat.
- Match upstream missing-checkpoint behavior: `create_view` reports the upstream not-found text, while `read_checkpoint` returns empty text for missing data.
- Align delete pseudo-element handling with upstream `extractViewportAndElements` by hiding inline-deleted elements with opacity `1` instead of dropping them, and keep restore-checkpoint deletes filtering restored base elements.
- Accept numeric delete ids similarly to upstream string coercion.

Intentionally ignored upstream MCP Apps widget/runtime-specific behavior:

- Did not add the upstream widget `read_widget_context` instruction because ExcalidrawZ does not expose that MCP Apps host tool in this compatibility mode.
- Did not move ExcalidrawZ transport, canvas bridge, file creation, viewport application, or storage safety into UpstreamCompat.
- Did not add the upstream widget export/runtime UI behavior.

## Validation

- `git diff --check -- ExcalidrawZ/Utils/MCP/UpstreamCompat/ExcalidrawMCPUpstreamElementResolver.swift ExcalidrawZ/Utils/MCP/UpstreamCompat/ExcalidrawMCPUpstreamToolHandler.swift`
- `xcrun swiftc -module-cache-path /Users/chocoford/.codex/automations/check-excalidraw-mcp-upstream-drift/SwiftModuleCache -typecheck ...UpstreamCompat files + MCPJSONValue.swift + MCPJSONRPC.swift`
- Full `ExcalidrawZ` simulator build was attempted with XcodeBuildMCP, but this automation worktree is missing the project resource `excalidraw-latest`, so Xcode stopped before compiling these files.