### PR TITLE
Sync Excalidraw MCP upstream contract text

### DIFF
--- a/ExcalidrawZ/Utils/MCP/UpstreamCompat/ExcalidrawMCPUpstreamElementResolver.swift
+++ b/ExcalidrawZ/Utils/MCP/UpstreamCompat/ExcalidrawMCPUpstreamElementResolver.swift
@@ -11,7 +11,7 @@ struct ExcalidrawMCPCheckpointNotFoundError: LocalizedError, Sendable {
     let id: String
 
     var errorDescription: String? {
-        "Checkpoint \"\(id)\" not found — it may have expired or never existed.\nPlease recreate the diagram from scratch."
+        "Checkpoint \"\(id)\" not found — it may have expired or never existed. Please recreate the diagram from scratch."
     }
 }
 

--- a/ExcalidrawZ/Utils/MCP/UpstreamCompat/ExcalidrawMCPUpstreamToolHandler.swift
+++ b/ExcalidrawZ/Utils/MCP/UpstreamCompat/ExcalidrawMCPUpstreamToolHandler.swift
@@ -71,7 +71,7 @@ struct ExcalidrawMCPUpstreamToolHandler {
             parsedElements = try MCPJSONValue.parseJSONArray(from: inputData)
         } catch {
             return ExcalidrawMCPToolResult(
-                text: "Invalid JSON in elements: \(error.localizedDescription).\nEnsure no comments, no trailing commas, and proper quoting.",
+                text: "Invalid JSON in elements: \(error.localizedDescription). Ensure no comments, no trailing commas, and proper quoting.",
                 isError: true
             )
         }
@@ -99,8 +99,14 @@ struct ExcalidrawMCPUpstreamToolHandler {
 
         return ExcalidrawMCPToolResult(
             text: """
-            Diagram displayed! Checkpoint id: "\(published.checkpointID)". If user asks to create a new diagram - simply create a new one from scratch.
-            However, if the user wants to edit something on this diagram "\(published.checkpointID)", use this one as starting checkpoint: simply start from the first element [{"type":"restoreCheckpoint","id":"\(published.checkpointID)"}, ...your new elements...] this will use same diagram state as the user currently sees, including any manual edits captured by the app, allowing you to add elements on top. To remove elements, use: {"type":"delete","ids":","}\(ratioHint)
+            Diagram displayed! Checkpoint id: "\(published.checkpointID)".
+            If user asks to create a new diagram - simply create a new one from scratch.
+            However, if the user wants to edit something on this diagram "\(published.checkpointID)", take these steps:
+            1) read widget context (using read_widget_context tool) to check if user made any manual edits first
+            2) decide whether you want to make new diagram from scratch OR - use this one as starting checkpoint:
+              simply start from the first element [{"type":"restoreCheckpoint","id":"\(published.checkpointID)"}, ...your new elements...]
+              this will use same diagram state as the user currently sees, including any manual edits they made in fullscreen, allowing you to add elements on top.
+              To remove elements, use: {"type":"delete","ids":"<id1>,<id2>"}\(ratioHint)
             """,
             structuredContent: .object([
                 "checkpointId": .string(published.checkpointID)

--- a/ExcalidrawZ/Utils/MCP/UpstreamCompat/ExcalidrawMCPUpstreamTools.swift
+++ b/ExcalidrawZ/Utils/MCP/UpstreamCompat/ExcalidrawMCPUpstreamTools.swift
@@ -151,7 +151,7 @@ enum ExcalidrawMCPToolSchemas {
             "elements": .object([
                 "type": .string("string"),
                 "description": .string(
-                    "JSON array string of Excalidraw elements. Must be valid JSON — no comments, no trailing commas. Keep compact.\nCall read_me first for format reference."
+                    "JSON array string of Excalidraw elements. Must be valid JSON — no comments, no trailing commas. Keep compact. Call read_me first for format reference."
                 )
             ])
         ]),
@@ -163,8 +163,7 @@ enum ExcalidrawMCPToolSchemas {
         "type": .string("object"),
         "properties": .object([
             "id": .object([
-                "type": .string("string"),
-                "description": .string("Checkpoint id returned by create_view or save_checkpoint.")
+                "type": .string("string")
             ])
         ]),
         "required": .array([.string("id")]),
@@ -175,12 +174,10 @@ enum ExcalidrawMCPToolSchemas {
         "type": .string("object"),
         "properties": .object([
             "id": .object([
-                "type": .string("string"),
-                "description": .string("Checkpoint id to update.")
+                "type": .string("string")
             ]),
             "data": .object([
-                "type": .string("string"),
-                "description": .string("Serialized checkpoint data JSON.")
+                "type": .string("string")
             ])
         ]),
         "required": .array([
@@ -209,7 +206,11 @@ enum ExcalidrawMCPUpstreamToolCatalog {
         ExcalidrawMCPTool(
             name: ExcalidrawMCPUpstreamContract.ToolName.createView,
             title: "Draw Diagram",
-            description: "Renders a hand-drawn diagram using Excalidraw elements. Elements stream in one by one with draw-on animations. Call read_me first to learn the element format.",
+            description: """
+            Renders a hand-drawn diagram using Excalidraw elements.
+            Elements stream in one by one with draw-on animations.
+            Call read_me first to learn the element format.
+            """,
             inputSchema: ExcalidrawMCPToolSchemas.createView,
             annotations: ["readOnlyHint": .bool(true)]
         ),


### PR DESCRIPTION
## Summary

- Sync `create_view` result text with current `excalidraw/excalidraw-mcp@main`, including the widget-context-first checkpoint editing guidance and corrected delete pseudo-element example.
- Align invalid JSON and checkpoint-not-found wording with upstream server behavior.
- Tighten UpstreamCompat tool descriptions and app-only checkpoint schemas to match upstream registration shape.

## Intentionally not synced

- MCP Apps widget UI/runtime changes in `src/mcp-app.tsx`, including fullscreen editor chrome, export UI, safe-area handling, host context lifecycle, and browser-specific rendering details.
- Upstream `export_to_excalidraw` server proxy behavior, because ExcalidrawZ keeps app-specific HTTP/export transport and native UI concerns outside UpstreamCompat.
- Package/runtime dependency metadata from `package.json` beyond already-tracked upstream version/identity constants.

## Validation

- `xcrun swiftc -parse ExcalidrawZ/Utils/MCP/UpstreamCompat/ExcalidrawMCPUpstreamToolHandler.swift ExcalidrawZ/Utils/MCP/UpstreamCompat/ExcalidrawMCPUpstreamTools.swift ExcalidrawZ/Utils/MCP/UpstreamCompat/ExcalidrawMCPUpstreamElementResolver.swift`

Upstream inspected: `src/server.ts`, `src/mcp-app.tsx`, `manifest.json`, and `package.json` from `excalidraw/excalidraw-mcp@main`.