### PR TITLE
fix: deadlock when quiting the app

### DIFF
--- a/ExcalidrawZ/AppDelegate.swift
+++ b/ExcalidrawZ/AppDelegate.swift
@@ -49,14 +49,72 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         isHandlingApplicationTermination = true
+        showSavingPanel()
         Task { @MainActor in
             defer {
                 isHandlingApplicationTermination = false
             }
             await prepareForApplicationTermination()
+            closeSavingPanel()
             sender.reply(toApplicationShouldTerminate: true)
         }
         return .terminateLater
+    }
+
+    // MARK: - Saving panel shown while flushing state at quit
+    private var savingPanel: NSWindow?
+
+    private func showSavingPanel() {
+        guard savingPanel == nil else { return }
+
+        let panel = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 260, height: 96),
+            styleMask: [.titled, .fullSizeContentView, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        panel.titleVisibility = .hidden
+        panel.titlebarAppearsTransparent = true
+        panel.standardWindowButton(.closeButton)?.isHidden = true
+        panel.standardWindowButton(.miniaturizeButton)?.isHidden = true
+        panel.standardWindowButton(.zoomButton)?.isHidden = true
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.level = .floating
+        panel.collectionBehavior = [.canJoinAllSpaces, .ignoresCycle]
+
+        let effect = NSVisualEffectView(frame: NSRect(x: 0, y: 0, width: 260, height: 96))
+        effect.material = .hudWindow
+        effect.blendingMode = .behindWindow
+        effect.state = .active
+
+        let spinner = NSProgressIndicator()
+        spinner.style = .spinning
+        spinner.controlSize = .regular
+        spinner.startAnimation(nil)
+
+        let label = NSTextField(labelWithString: "Saving changes…")
+        label.font = .systemFont(ofSize: 13, weight: .medium)
+
+        let stack = NSStackView(views: [spinner, label])
+        stack.orientation = .horizontal
+        stack.spacing = 12
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        effect.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.centerXAnchor.constraint(equalTo: effect.centerXAnchor),
+            stack.centerYAnchor.constraint(equalTo: effect.centerYAnchor)
+        ])
+
+        panel.contentView = effect
+        panel.center()
+        panel.makeKeyAndOrderFront(nil)
+        savingPanel = panel
+    }
+
+    private func closeSavingPanel() {
+        savingPanel?.orderOut(nil)
+        savingPanel = nil
     }
     
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {

--- a/ExcalidrawZ/AppDelegate.swift
+++ b/ExcalidrawZ/AppDelegate.swift
@@ -35,9 +35,66 @@ final class ApplicationTerminationCanvasFlushCoordinator {
     }
 }
 
+@MainActor
+final class ApplicationTerminationPresentationCoordinator: ObservableObject {
+    static let shared = ApplicationTerminationPresentationCoordinator()
+
+    @Published private(set) var targetWindowNumber: Int?
+    @Published private(set) var stage: ApplicationTerminationStage = .screenAnnotationSaves
+
+    private var cancelAction: (() -> Void)?
+    private var forceQuitAction: (() -> Void)?
+
+    private init() {}
+
+    func update(stage: ApplicationTerminationStage) {
+        self.stage = stage
+    }
+
+    func present(
+        on windowNumber: Int,
+        cancelAction: @escaping () -> Void,
+        forceQuitAction: @escaping () -> Void
+    ) {
+        self.cancelAction = cancelAction
+        self.forceQuitAction = forceQuitAction
+        targetWindowNumber = windowNumber
+    }
+
+    func dismiss() {
+        targetWindowNumber = nil
+        cancelAction = nil
+        forceQuitAction = nil
+    }
+
+    func cancelTermination() {
+        let action = cancelAction
+        dismiss()
+        action?()
+    }
+
+    func forceQuit() {
+        let action = forceQuitAction
+        dismiss()
+        action?()
+    }
+}
+
+enum ApplicationTerminationStage {
+    case screenAnnotationSaves
+    case backgroundDocumentOperations
+    case currentDrawing
+    case applicationData
+    case backup
+}
+
 class AppDelegate: NSObject, NSApplicationDelegate {
     let logger = Logger(label: "AppDelegate")
     private var isHandlingApplicationTermination = false
+    private var terminationTask: Task<Void, Never>?
+    private var terminationPresentationTask: Task<Void, Never>?
+
+    private static let terminationPresentationDelay: UInt64 = 600_000_000
     
     func applicationWillTerminate(_ notification: Notification) {
         PersistenceController.shared.save()
@@ -49,72 +106,70 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         isHandlingApplicationTermination = true
-        showSavingPanel()
-        Task { @MainActor in
-            defer {
-                isHandlingApplicationTermination = false
-            }
+        scheduleTerminationSheetIfNeeded(for: sender)
+        terminationTask = Task { @MainActor [weak self, weak sender] in
+            guard let self, let sender else { return }
             await prepareForApplicationTermination()
-            closeSavingPanel()
-            sender.reply(toApplicationShouldTerminate: true)
+            guard !Task.isCancelled, isHandlingApplicationTermination else {
+                return
+            }
+            finishTerminationRequest(sender, shouldTerminate: true)
         }
         return .terminateLater
     }
 
-    // MARK: - Saving panel shown while flushing state at quit
-    private var savingPanel: NSWindow?
+    @MainActor
+    private func scheduleTerminationSheetIfNeeded(for application: NSApplication) {
+        guard application.isActive,
+              let window = application.mainWindow,
+              window.isVisible,
+              !window.isMiniaturized else {
+            return
+        }
 
-    private func showSavingPanel() {
-        guard savingPanel == nil else { return }
+        let windowNumber = window.windowNumber
+        terminationPresentationTask = Task { @MainActor [weak self, weak application] in
+            try? await Task.sleep(nanoseconds: Self.terminationPresentationDelay)
+            guard let self,
+                  let application,
+                  !Task.isCancelled,
+                  isHandlingApplicationTermination,
+                  application.isActive,
+                  let targetWindow = application.windows.first(where: {
+                      $0.windowNumber == windowNumber
+                  }),
+                  targetWindow.isVisible,
+                  !targetWindow.isMiniaturized else {
+                return
+            }
 
-        let panel = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 260, height: 96),
-            styleMask: [.titled, .fullSizeContentView, .closable],
-            backing: .buffered,
-            defer: false
-        )
-        panel.titleVisibility = .hidden
-        panel.titlebarAppearsTransparent = true
-        panel.standardWindowButton(.closeButton)?.isHidden = true
-        panel.standardWindowButton(.miniaturizeButton)?.isHidden = true
-        panel.standardWindowButton(.zoomButton)?.isHidden = true
-        panel.isOpaque = false
-        panel.backgroundColor = .clear
-        panel.level = .floating
-        panel.collectionBehavior = [.canJoinAllSpaces, .ignoresCycle]
-
-        let effect = NSVisualEffectView(frame: NSRect(x: 0, y: 0, width: 260, height: 96))
-        effect.material = .hudWindow
-        effect.blendingMode = .behindWindow
-        effect.state = .active
-
-        let spinner = NSProgressIndicator()
-        spinner.style = .spinning
-        spinner.controlSize = .regular
-        spinner.startAnimation(nil)
-
-        let label = NSTextField(labelWithString: "Saving changes…")
-        label.font = .systemFont(ofSize: 13, weight: .medium)
-
-        let stack = NSStackView(views: [spinner, label])
-        stack.orientation = .horizontal
-        stack.spacing = 12
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        effect.addSubview(stack)
-        NSLayoutConstraint.activate([
-            stack.centerXAnchor.constraint(equalTo: effect.centerXAnchor),
-            stack.centerYAnchor.constraint(equalTo: effect.centerYAnchor)
-        ])
-
-        panel.contentView = effect
-        panel.center()
-        panel.makeKeyAndOrderFront(nil)
-        savingPanel = panel
+            ApplicationTerminationPresentationCoordinator.shared.present(
+                on: windowNumber,
+                cancelAction: { [weak self, weak application] in
+                    guard let self, let application else { return }
+                    self.finishTerminationRequest(application, shouldTerminate: false)
+                },
+                forceQuitAction: { [weak self, weak application] in
+                    guard let self, let application else { return }
+                    self.finishTerminationRequest(application, shouldTerminate: true)
+                }
+            )
+        }
     }
 
-    private func closeSavingPanel() {
-        savingPanel?.orderOut(nil)
-        savingPanel = nil
+    @MainActor
+    private func finishTerminationRequest(
+        _ application: NSApplication,
+        shouldTerminate: Bool
+    ) {
+        guard isHandlingApplicationTermination else { return }
+        terminationPresentationTask?.cancel()
+        terminationPresentationTask = nil
+        terminationTask?.cancel()
+        terminationTask = nil
+        ApplicationTerminationPresentationCoordinator.shared.dismiss()
+        isHandlingApplicationTermination = false
+        application.reply(toApplicationShouldTerminate: shouldTerminate)
     }
     
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
@@ -123,11 +178,27 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @MainActor
     private func prepareForApplicationTermination() async {
+        guard !Task.isCancelled else { return }
+        updateTerminationStage(.screenAnnotationSaves)
         await ScreenAnnotationSaveTaskManager.shared.waitUntilIdle()
+        guard !Task.isCancelled else { return }
+        updateTerminationStage(.backgroundDocumentOperations)
         await OffscreenExcalidrawEditor.waitForPendingOperations()
+        guard !Task.isCancelled else { return }
+        updateTerminationStage(.currentDrawing)
         await ApplicationTerminationCanvasFlushCoordinator.shared.flushPendingCanvasSnapshot()
+        guard !Task.isCancelled else { return }
+        updateTerminationStage(.applicationData)
         PersistenceController.shared.save()
+        guard !Task.isCancelled else { return }
+        updateTerminationStage(.backup)
         await backupFilesBeforeTermination()
+    }
+
+    @MainActor
+    private func updateTerminationStage(_ stage: ApplicationTerminationStage) {
+        guard isHandlingApplicationTermination else { return }
+        ApplicationTerminationPresentationCoordinator.shared.update(stage: stage)
     }
 
     @MainActor

--- a/ExcalidrawZ/ContentView.swift
+++ b/ExcalidrawZ/ContentView.swift
@@ -32,6 +32,9 @@ struct ContentView: View {
     @EnvironmentObject private var lockedContentState: LockedContentStateStore
     @ObservedObject private var aiChatPreferences = AIChatPreferences.shared
     @ObservedObject private var cloudStorageConnections = CloudStorageConnectionStore.shared
+#if os(macOS)
+    @ObservedObject private var applicationTerminationPresentation = ApplicationTerminationPresentationCoordinator.shared
+#endif
     
     @AppStorage("DisableCloudSync") var isICloudDisabled: Bool = false
     
@@ -86,6 +89,17 @@ struct ContentView: View {
             .swiftyAlert(logs: true)
             .bindWindow($window)
 #if os(macOS)
+            .sheet(isPresented: applicationTerminationSheetBinding) {
+                ApplicationTerminationSheet(
+                    stage: applicationTerminationPresentation.stage,
+                    cancelAction: {
+                        applicationTerminationPresentation.cancelTermination()
+                    },
+                    forceQuitAction: {
+                        applicationTerminationPresentation.forceQuit()
+                    }
+                )
+            }
             .task(id: window?.windowNumber) {
                 guard let window else { return }
                 ScreenAnnotationController.shared.register(
@@ -186,6 +200,18 @@ struct ContentView: View {
             }
     }
 
+#if os(macOS)
+    private var applicationTerminationSheetBinding: Binding<Bool> {
+        Binding(
+            get: {
+                guard let window else { return false }
+                return applicationTerminationPresentation.targetWindowNumber == window.windowNumber
+            },
+            set: { _ in }
+        )
+    }
+#endif
+
     private var connectedCloudStorageLocationIDs: Set<UUID> {
         Set(cloudStorageConnections.locations.map(\.id))
     }
@@ -258,6 +284,85 @@ struct ContentView: View {
         try? await fileState.mergeDefaultGroupAndTrashIfNeeded(context: viewContext)
     }
 }
+
+#if os(macOS)
+private struct ApplicationTerminationSheet: View {
+    let stage: ApplicationTerminationStage
+    let cancelAction: () -> Void
+    let forceQuitAction: () -> Void
+
+    @State private var forceQuitDelayRemaining = 3
+
+    var body: some View {
+        VStack(spacing: 20) {
+            ProgressView()
+                .controlSize(.small)
+
+            VStack(spacing: 6) {
+                Text(.localizable(.applicationTerminationTitle))
+                    .font(.headline)
+
+                stageDescription
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            HStack {
+                Spacer()
+
+                Button(.localizable(.generalButtonCancel), action: cancelAction)
+                    .keyboardShortcut(.cancelAction)
+                    .modernButtonStyle(
+                        style: .glass,
+                        size: .regular,
+                        shape: .capsule
+                    )
+
+                Button(
+                    .localizable(.applicationTerminationForceQuitButton),
+                    role: .destructive,
+                    action: forceQuitAction
+                )
+                .disabled(forceQuitDelayRemaining > 0)
+                .modernButtonStyle(
+                    style: .glassProminent,
+                    size: .regular,
+                    shape: .capsule
+                )
+                .tint(.red)
+            }
+        }
+        .padding(24)
+        .frame(width: 360)
+        .interactiveDismissDisabled()
+        .task {
+            forceQuitDelayRemaining = 3
+            while forceQuitDelayRemaining > 0 {
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                guard !Task.isCancelled else { return }
+                forceQuitDelayRemaining -= 1
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var stageDescription: some View {
+        switch stage {
+            case .screenAnnotationSaves:
+                Text(.localizable(.applicationTerminationStageScreenAnnotationSaves))
+            case .backgroundDocumentOperations:
+                Text(.localizable(.applicationTerminationStageBackgroundDocumentOperations))
+            case .currentDrawing:
+                Text(.localizable(.applicationTerminationStageCurrentDrawing))
+            case .applicationData:
+                Text(.localizable(.applicationTerminationStageApplicationData))
+            case .backup:
+                Text(.localizable(.applicationTerminationStageBackup))
+        }
+    }
+}
+#endif
 
 private struct ActiveFileSwitchBlockedToastModifier: ViewModifier {
     @Environment(\.alertToast) private var alertToast

--- a/ExcalidrawZ/Localizable.xcstrings
+++ b/ExcalidrawZ/Localizable.xcstrings
@@ -8589,6 +8589,797 @@
         }
       }
     },
+    "applicationTerminationStageApplicationData": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saving application data…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在保存应用数据…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在保存應用程式資料…"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جارٍ حفظ بيانات التطبيق..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anwendungsdaten werden gespeichert…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardando los datos de la aplicación…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrement des données de l'application…"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आवेदन डेटा सहेजना…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salvataggio dei dati dell'applicazione…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリケーションデータを保存しています…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "응용 프로그램 데이터 저장 중…"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toepassen van gegevens opslaan…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zapisywanie danych aplikacji…"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salvando dados do aplicativo…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сохранение данных приложения…"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กำลังบันทึกข้อมูลแอปพลิเคชัน…"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uygulama verileri kaydediliyor…"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang lưu dữ liệu ứng dụng…"
+          }
+        }
+      }
+    },
+    "applicationTerminationStageBackgroundDocumentOperations": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finishing pending document operations…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在完成待处理的文档操作…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在完成待處理的文檔操作…"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جارٍ إنهاء العمليات المعلقة على المستند..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausstehende Dokumentoperationen werden abgeschlossen…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalizando operaciones de documentos pendientes…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalisation des opérations de document en attente…"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लंबित दस्तावेज़ संचालन को पूरा करना…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Completamento delle operazioni sui documenti in sospeso…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保留中のドキュメント操作を完了しています…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "보류 중인 문서 작업 마무리 중…"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afronden van lopende documentbewerkingen…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kończenie oczekujących operacji na dokumentach…"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalizando operações de documentos pendentes…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завершение ожидающих операций с документами…"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กำลังเสร็จสิ้นการดำเนินการเอกสารที่รอดำเนินการ…"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bekleyen belge işlemleri tamamlanıyor…"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang hoàn tất các thao tác tài liệu còn lại…"
+          }
+        }
+      }
+    },
+    "applicationTerminationStageBackup": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creating a backup…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在创建备份…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在建立備份…"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جارٍ إنشاء نسخة احتياطية..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erstelle ein Backup…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creando una copia de seguridad…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Création d'une sauvegarde…"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बैकअप बना रहा है…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creazione di un backup…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バックアップを作成しています…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "백업 생성 중…"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Een back-up maken…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tworzenie kopii zapasowej…"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criando um backup…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Создание резервной копии…"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กำลังสร้างสำเนาสำรอง…"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yedek oluşturuluyor…"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang tạo bản sao lưu…"
+          }
+        }
+      }
+    },
+    "applicationTerminationStageCurrentDrawing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saving the current drawing…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在保存当前绘图…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在保存當前圖紙…"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جارٍ حفظ الرسم الحالي..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das aktuelle Zeichnen wird gespeichert…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardando el dibujo actual…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrement du dessin actuel…"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "वर्तमान चित्र को सहेजना…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salvataggio del disegno corrente…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在の図面を保存しています…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 드로잉 저장 중…"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "De huidige tekening opslaan…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zapisywanie bieżącego rysunku…"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salvando o desenho atual…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сохранение текущего чертежа…"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กำลังบันทึกภาพวาดปัจจุบัน…"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mevcut çizim kaydediliyor…"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang lưu bản vẽ hiện tại…"
+          }
+        }
+      }
+    },
+    "applicationTerminationStageScreenAnnotationSaves": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finishing pending screen annotation saves…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在完成待处理的屏幕注释保存…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在完成待處理的螢幕標註儲存…"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جارٍ إنهاء حفظ تعليقات الشاشة المعلقة..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausstehende Bildschirmannotation-Speicher werden abgeschlossen…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalizando los guardados de anotaciones de pantalla pendientes…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalisation des enregistrements d'annotations d'écran en attente…"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लंबित स्क्रीन एनोटेशन सहेजने को पूरा करना…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Completamento dei salvataggi delle annotazioni dello schermo in sospeso…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保留中のスクリーン注釈の保存を完了しています…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "보류 중인 화면 주석 저장 마무리 중…"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afronden van lopende schermannotatie-opslag…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kończenie oczekujących zapisów adnotacji na ekranie…"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalizando saves de anotações na tela pendentes…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завершение ожидающих сохранений аннотаций на экране…"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กำลังเสร็จสิ้นการบันทึกการทำเครื่องหมายบนหน้าจอที่รอดำเนินการ…"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bekleyen ekran notları kaydediliyor…"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang hoàn tất việc lưu chú thích màn hình còn lại…"
+          }
+        }
+      }
+    },
+    "applicationTerminationTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitting ExcalidrawZ…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在退出 ExcalidrawZ…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在退出 ExcalidrawZ…"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يتم الخروج من ExcalidrawZ..."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ExcalidrawZ wird beendet…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saliendo de ExcalidrawZ…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fermeture d'ExcalidrawZ…"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ExcalidrawZ से बाहर निकलना…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uscita da ExcalidrawZ…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ExcalidrawZを終了しています…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ExcalidrawZ 종료 중…"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ExcalidrawZ afsluiten…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zamykanie ExcalidrawZ…"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saindo do ExcalidrawZ…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выход из ExcalidrawZ…"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กำลังออกจาก ExcalidrawZ…"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ExcalidrawZ'den çıkış yapılıyor…"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang thoát ExcalidrawZ…"
+          }
+        }
+      }
+    },
+    "applicationTerminationForceQuitButton": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Force Quit"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "强制退出"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "強制退出"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خروج قسري"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sofort Beenden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Forzar salida"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Forcer à quitter"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "फोर्स क्विट"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Forza uscita"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "強制終了"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "강제 종료"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Forceer beëindigen"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wymuś zamknięcie"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Forçar saída"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Принудительно выйти"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "บังคับออก"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zorla Çık"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buộc thoát"
+          }
+        }
+      }
+    },
     "aiChatActiveFileSwitchBlockedToastTitle": {
       "extractionState": "manual",
       "localizations": {

--- a/ExcalidrawZ/Share/ExportFileView.swift
+++ b/ExcalidrawZ/Share/ExportFileView.swift
@@ -53,18 +53,9 @@ struct ExportFileView: View {
                             .resizable()
                             .aspectRatio(contentMode: .fit)
                             .frame(height: 80)
-#if os(macOS)
-                            // .draggable leaves lazy pasteboard promises that deadlock CFPasteboardResolveAllPromisedData on quit; onDrag carries an eager file URL
                             .onDrag {
-                                let url = (try? file.fileURL()) ?? URL(fileURLWithPath: "/dev/null")
-                                return NSItemProvider(
-                                    item: url.dataRepresentation as NSData,
-                                    typeIdentifier: UTType.fileURL.identifier
-                                )
+                                makeFileDragItemProvider()
                             }
-#else
-                            .draggable(file)
-#endif
                             .padding()
                     } else {
                         Image(nsImage: NSWorkspace.shared.icon(for: .excalidrawFile))
@@ -113,6 +104,22 @@ struct ExportFileView: View {
             }
         }
     }
+
+#if os(macOS)
+    @available(macOS 13.0, *)
+    private func makeFileDragItemProvider() -> NSItemProvider {
+        do {
+            let url = try file.fileURL()
+            return NSItemProvider(
+                item: url.dataRepresentation as NSData,
+                typeIdentifier: UTType.fileURL.identifier
+            )
+        } catch {
+            alertToast(error)
+            return NSItemProvider()
+        }
+    }
+#endif
     
     @ViewBuilder
     private func actionsView() -> some View {

--- a/ExcalidrawZ/Share/ExportFileView.swift
+++ b/ExcalidrawZ/Share/ExportFileView.swift
@@ -53,7 +53,18 @@ struct ExportFileView: View {
                             .resizable()
                             .aspectRatio(contentMode: .fit)
                             .frame(height: 80)
+#if os(macOS)
+                            // .draggable leaves lazy pasteboard promises that deadlock CFPasteboardResolveAllPromisedData on quit; onDrag carries an eager file URL
+                            .onDrag {
+                                let url = (try? file.fileURL()) ?? URL(fileURLWithPath: "/dev/null")
+                                return NSItemProvider(
+                                    item: url.dataRepresentation as NSData,
+                                    typeIdentifier: UTType.fileURL.identifier
+                                )
+                            }
+#else
                             .draggable(file)
+#endif
                             .padding()
                     } else {
                         Image(nsImage: NSWorkspace.shared.icon(for: .excalidrawFile))

--- a/ExcalidrawZ/SidebarTrailing/AIChat/components/ToolCards/AIProposalToolResultCard.swift
+++ b/ExcalidrawZ/SidebarTrailing/AIChat/components/ToolCards/AIProposalToolResultCard.swift
@@ -106,34 +106,26 @@ struct AIProposalToolResultCard: View {
 
 #if os(macOS)
     private func makeProposalDragItemProvider() -> NSItemProvider {
-        let itemProvider = NSItemProvider()
-        itemProvider.registerDataRepresentation(
-            forTypeIdentifier: UTType.excalidrawlibJSON.identifier,
-            visibility: .ownProcess
-        ) { completion in
-            do {
-                let library = ExcalidrawLibrary(
-                    type: "excalidrawlib",
-                    version: 2,
-                    source: "https://excalidraw.com",
-                    libraryItems: [
-                        ExcalidrawLibrary.Item(
-                            id: UUID().uuidString,
-                            status: .published,
-                            createdAt: Date(),
-                            name: String(localizable: .aiProposalDragName),
-                            elements: artifact.visibleElements
-                        )
-                    ]
+        // Eager data: lazy promises (registerDataRepresentation) deadlock
+        // CFPasteboardResolveAllPromisedData at app quit.
+        let library = ExcalidrawLibrary(
+            type: "excalidrawlib",
+            version: 2,
+            source: "https://excalidraw.com",
+            libraryItems: [
+                ExcalidrawLibrary.Item(
+                    id: UUID().uuidString,
+                    status: .published,
+                    createdAt: Date(),
+                    name: String(localizable: .aiProposalDragName),
+                    elements: artifact.visibleElements
                 )
-                let data = Data(try library.jsonStringified().utf8)
-                completion(data, nil)
-            } catch {
-                completion(nil, error)
-            }
-            return Progress(totalUnitCount: 1)
+            ]
+        )
+        guard let data = (try? library.jsonStringified().data(using: .utf8)) as NSData? else {
+            return NSItemProvider()
         }
-        return itemProvider
+        return NSItemProvider(item: data, typeIdentifier: UTType.excalidrawlibJSON.identifier)
     }
 #endif
 

--- a/ExcalidrawZ/SidebarTrailing/AIChat/components/ToolCards/AIProposalToolResultCard.swift
+++ b/ExcalidrawZ/SidebarTrailing/AIChat/components/ToolCards/AIProposalToolResultCard.swift
@@ -106,8 +106,6 @@ struct AIProposalToolResultCard: View {
 
 #if os(macOS)
     private func makeProposalDragItemProvider() -> NSItemProvider {
-        // Eager data: lazy promises (registerDataRepresentation) deadlock
-        // CFPasteboardResolveAllPromisedData at app quit.
         let library = ExcalidrawLibrary(
             type: "excalidrawlib",
             version: 2,
@@ -122,10 +120,16 @@ struct AIProposalToolResultCard: View {
                 )
             ]
         )
-        guard let data = (try? library.jsonStringified().data(using: .utf8)) as NSData? else {
+        do {
+            let data = Data(try library.jsonStringified().utf8)
+            return NSItemProvider(
+                item: data as NSData,
+                typeIdentifier: UTType.excalidrawlibJSON.identifier
+            )
+        } catch {
+            alertToast(error)
             return NSItemProvider()
         }
-        return NSItemProvider(item: data, typeIdentifier: UTType.excalidrawlibJSON.identifier)
     }
 #endif
 

--- a/ExcalidrawZ/SidebarTrailing/Library/LibraryItemView.swift
+++ b/ExcalidrawZ/SidebarTrailing/Library/LibraryItemView.swift
@@ -60,24 +60,17 @@ struct LibraryItemView: View {
 #if os(macOS)
         content()
             .onDrag {
-                let itemProvider = NSItemProvider()
-                itemProvider.registerDataRepresentation(
-                    forTypeIdentifier: UTType.excalidrawlibJSON.identifier,
-                    visibility: .ownProcess
-                ) { completion in
-                    viewContext.perform {
-                        do {
-                            let item = item.excalidrawLibrary
-                            let data = try item.jsonStringified().data(using: .utf8)
-                            completion(data, nil)
-                        } catch {
-                            alertToast(error)
-                            completion(nil, error)
-                        }
-                    }
-                    return Progress(totalUnitCount: 100)
+                // Eager data: lazy promises (registerDataRepresentation) deadlock
+                // CFPasteboardResolveAllPromisedData at app quit.
+                var data: NSData?
+                viewContext.performAndWait {
+                    data = (try? item.excalidrawLibrary.jsonStringified().data(using: .utf8)) as NSData?
                 }
-                return itemProvider
+                if let data {
+                    return NSItemProvider(item: data, typeIdentifier: UTType.excalidrawlibJSON.identifier)
+                } else {
+                    return NSItemProvider()
+                }
             }
             .modifier(LibraryItemContentBackgroundModifier())
             .simultaneousGesture(TapGesture(count: 2).onEnded {

--- a/ExcalidrawZ/SidebarTrailing/Library/LibraryItemView.swift
+++ b/ExcalidrawZ/SidebarTrailing/Library/LibraryItemView.swift
@@ -60,17 +60,7 @@ struct LibraryItemView: View {
 #if os(macOS)
         content()
             .onDrag {
-                // Eager data: lazy promises (registerDataRepresentation) deadlock
-                // CFPasteboardResolveAllPromisedData at app quit.
-                var data: NSData?
-                viewContext.performAndWait {
-                    data = (try? item.excalidrawLibrary.jsonStringified().data(using: .utf8)) as NSData?
-                }
-                if let data {
-                    return NSItemProvider(item: data, typeIdentifier: UTType.excalidrawlibJSON.identifier)
-                } else {
-                    return NSItemProvider()
-                }
+                makeLibraryItemDragProvider()
             }
             .modifier(LibraryItemContentBackgroundModifier())
             .simultaneousGesture(TapGesture(count: 2).onEnded {
@@ -110,6 +100,33 @@ struct LibraryItemView: View {
         }
 #endif
     }
+
+#if os(macOS)
+    private func makeLibraryItemDragProvider() -> NSItemProvider {
+        var result: Result<Data, Error>?
+        viewContext.performAndWait {
+            result = Result {
+                let json = try item.excalidrawLibrary.jsonStringified()
+                return Data(json.utf8)
+            }
+        }
+
+        guard let result else {
+            return NSItemProvider()
+        }
+
+        switch result {
+            case .success(let data):
+                return NSItemProvider(
+                    item: data as NSData,
+                    typeIdentifier: UTType.excalidrawlibJSON.identifier
+                )
+            case .failure(let error):
+                alertToast(error)
+                return NSItemProvider()
+        }
+    }
+#endif
     
     @ViewBuilder
     private func content() -> some View {

--- a/ExcalidrawZ/components/FlexibleSplitView/FlexibleSplitView.swift
+++ b/ExcalidrawZ/components/FlexibleSplitView/FlexibleSplitView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import UniformTypeIdentifiers
 import ChocofordUI
 
 protocol FlexibleItem {
@@ -161,15 +160,6 @@ struct FlexibleSplitView<Item: FlexibleItem, ID: Hashable & Transferable>: View 
                     .foregroundStyle(.primary)
             }
             .contentShape(Rectangle())
-#if os(macOS)
-            // .draggable leaves lazy pasteboard promises that deadlock CFPasteboardResolveAllPromisedData on quit; onDrag carries eager data
-            .onDrag {
-                NSItemProvider(
-                    item: String(describing: item[keyPath: itemID]) as NSString,
-                    typeIdentifier: UTType.plainText.identifier
-                )
-            }
-#else
             .draggable(item[keyPath: itemID]) {
                 Text(item.title)
                     .fixedSize()
@@ -177,7 +167,6 @@ struct FlexibleSplitView<Item: FlexibleItem, ID: Hashable & Transferable>: View 
                     .padding(40)
                     .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
             }
-#endif
             .simultaneousGesture(DragGesture(minimumDistance: 0).onChanged { _ in
                 if self.draggedItemID != item[keyPath: itemID] {
                     self.draggedItemID = item[keyPath: itemID]

--- a/ExcalidrawZ/components/FlexibleSplitView/FlexibleSplitView.swift
+++ b/ExcalidrawZ/components/FlexibleSplitView/FlexibleSplitView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import UniformTypeIdentifiers
 import ChocofordUI
 
 protocol FlexibleItem {
@@ -160,6 +161,15 @@ struct FlexibleSplitView<Item: FlexibleItem, ID: Hashable & Transferable>: View 
                     .foregroundStyle(.primary)
             }
             .contentShape(Rectangle())
+#if os(macOS)
+            // .draggable leaves lazy pasteboard promises that deadlock CFPasteboardResolveAllPromisedData on quit; onDrag carries eager data
+            .onDrag {
+                NSItemProvider(
+                    item: String(describing: item[keyPath: itemID]) as NSString,
+                    typeIdentifier: UTType.plainText.identifier
+                )
+            }
+#else
             .draggable(item[keyPath: itemID]) {
                 Text(item.title)
                     .fixedSize()
@@ -167,6 +177,7 @@ struct FlexibleSplitView<Item: FlexibleItem, ID: Hashable & Transferable>: View 
                     .padding(40)
                     .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
             }
+#endif
             .simultaneousGesture(DragGesture(minimumDistance: 0).onChanged { _ in
                 if self.draggedItemID != item[keyPath: itemID] {
                     self.draggedItemID = item[keyPath: itemID]


### PR DESCRIPTION
Lazy pasteboard promises (SwiftUI .draggable, NSItemProvider
registerDataRepresentation) deadlock CFPasteboardResolveAllPromisedData
during NSApplication terminate, making the app appear to crash on Cmd+Q.

- Replace .draggable with eager onDrag NSItemProviders (ExportFileView,
  FlexibleSplitView)
- Register eager data for library item and AI proposal card drags
- Show a 'Saving changes…' panel while flushing state at quit

possibly fixing https://github.com/chocoford/ExcalidrawZ/issues/118