### PR TITLE
=> 2.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - Fixed remaining permission errors when opening external drawings from Files, reopening them from Temporary, or accessing Linked Folders on iPhone and iPad.
 - Fixed Linked Folders on iPhone and iPad failing to refresh while File Provider content was still downloading, with clearer availability feedback.
 - Fixed collaboration rooms on iPhone and iPad occasionally remaining stuck on the loading screen.
+- Fixed a macOS drag-and-drop event monitor remaining registered after its view disappeared.
+
+#### Optimizations
+
+- Refined File Home and group menus on Mac and iPad, including group-specific imports and consistent sidebar section controls.
 
 ## 2.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.4.2
+
+#### Bug fixed
+
+- Fixed remaining permission errors when opening external drawings from Files, reopening them from Temporary, or accessing Linked Folders on iPhone and iPad.
+- Fixed Linked Folders on iPhone and iPad failing to refresh while File Provider content was still downloading, with clearer availability feedback.
+- Fixed collaboration rooms on iPhone and iPad occasionally remaining stuck on the loading screen.
+
 ## 2.4.1
 
 #### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 #### Features
 
-- Added Linked Cloud Storage for OneDrive, Dropbox, Google Drive, and WebDAV (Beta), available across Mac, iPad, and iPhone alongside local linked folders.
+- Added Linked Cloud Storage for OneDrive, Dropbox, and WebDAV (Beta), available across Mac, iPad, and iPhone alongside local linked folders.
 - Added cloud conflict resolution with visual previews, allowing you to compare local and remote versions before choosing which one to keep.
 
 #### Optimizations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,18 @@
-## 2.4.2
+## 2.4.3
 
 #### Bug fixed
 
 - Fixed remaining permission errors when opening external drawings from Files, reopening them from Temporary, or accessing Linked Folders on iPhone and iPad.
 - Fixed Linked Folders on iPhone and iPad failing to refresh while File Provider content was still downloading, with clearer availability feedback.
 - Fixed collaboration rooms on iPhone and iPad occasionally remaining stuck on the loading screen.
+- Fixed Linked Folder drawings sometimes losing their containing folder context, which could affect sharing and return navigation.
+- Fixed iPad Sidebar scrolling not responding when a gesture started over a folder row.
+- Fixed iPad file transitions using a matching item from an inactive tab.
 - Fixed a macOS drag-and-drop event monitor remaining registered after its view disappeared.
 
 #### Optimizations
 
-- Refined File Home and group menus on Mac and iPad, including group-specific imports and consistent sidebar section controls.
+- Refined File Home and group menus on Mac and iPad, including group-specific imports and consistent Sidebar section controls.
 
 ## 2.4.1
 

--- a/ExcalidrawZ.xcodeproj/project.pbxproj
+++ b/ExcalidrawZ.xcodeproj/project.pbxproj
@@ -1028,7 +1028,7 @@
 				CODE_SIGN_ENTITLEMENTS = ExcalidrawZ/ExcalidrawZ.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 112;
+				CURRENT_PROJECT_VERSION = 113;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"ExcalidrawZ/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -1061,7 +1061,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				LOCALIZED_STRING_SWIFTUI_SUPPORT = NO;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.4.2;
+				MARKETING_VERSION = 2.4.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.chocoford.excalidraw-Debug";
 				PRODUCT_NAME = ExcalidrawZ;
 				SDKROOT = auto;
@@ -1081,7 +1081,7 @@
 				CODE_SIGN_ENTITLEMENTS = ExcalidrawZ/ExcalidrawZ.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 112;
+				CURRENT_PROJECT_VERSION = 113;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"ExcalidrawZ/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -1114,7 +1114,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				LOCALIZED_STRING_SWIFTUI_SUPPORT = NO;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.4.2;
+				MARKETING_VERSION = 2.4.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.chocoford.excalidraw;
 				PRODUCT_NAME = ExcalidrawZ;
 				SDKROOT = auto;
@@ -1196,7 +1196,7 @@
 				CODE_SIGN_ENTITLEMENTS = ExcalidrawZ/ExcalidrawZ.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 112;
+				CURRENT_PROJECT_VERSION = 113;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"ExcalidrawZ/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -1229,7 +1229,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				LOCALIZED_STRING_SWIFTUI_SUPPORT = NO;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.4.2;
+				MARKETING_VERSION = 2.4.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.chocoford.excalidraw;
 				PRODUCT_NAME = ExcalidrawZ;
 				SDKROOT = auto;
@@ -1249,7 +1249,7 @@
 				CODE_SIGN_ENTITLEMENTS = ExcalidrawZ/ExcalidrawZ.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 112;
+				CURRENT_PROJECT_VERSION = 113;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"ExcalidrawZ/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -1289,7 +1289,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				LOCALIZED_STRING_SWIFTUI_SUPPORT = NO;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.4.2;
+				MARKETING_VERSION = 2.4.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.chocoford.excalidraw;
 				PRODUCT_NAME = ExcalidrawZ;
 				SDKROOT = auto;
@@ -1483,7 +1483,7 @@
 				CODE_SIGN_ENTITLEMENTS = ExcalidrawZ/ExcalidrawZ.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 112;
+				CURRENT_PROJECT_VERSION = 113;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"ExcalidrawZ/Preview Content\"";
 				DEVELOPMENT_TEAM = 3XKM749Y3L;
@@ -1524,7 +1524,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				LOCALIZED_STRING_SWIFTUI_SUPPORT = NO;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.4.2;
+				MARKETING_VERSION = 2.4.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.chocoford.excalidraw-Debug";
 				PRODUCT_NAME = ExcalidrawZ;
 				SDKROOT = auto;
@@ -1543,7 +1543,7 @@
 				CODE_SIGN_ENTITLEMENTS = ExcalidrawZ/ExcalidrawZ.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 112;
+				CURRENT_PROJECT_VERSION = 113;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"ExcalidrawZ/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -1583,7 +1583,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				LOCALIZED_STRING_SWIFTUI_SUPPORT = NO;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.4.2;
+				MARKETING_VERSION = 2.4.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.chocoford.excalidraw;
 				PRODUCT_NAME = ExcalidrawZ;
 				SDKROOT = auto;
@@ -1685,7 +1685,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = QuickLookPreviewExtension/QuickLookPreviewExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 112;
+				CURRENT_PROJECT_VERSION = 113;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
@@ -1702,7 +1702,7 @@
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.4.2;
+				MARKETING_VERSION = 2.4.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.chocoford.excalidraw-Debug.QuickLookPreviewExtension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1721,7 +1721,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = QuickLookPreviewExtension/QuickLookPreviewExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 112;
+				CURRENT_PROJECT_VERSION = 113;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
@@ -1738,7 +1738,7 @@
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.4.2;
+				MARKETING_VERSION = 2.4.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.chocoford.excalidraw.QuickLookPreviewExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1756,7 +1756,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = QuickLookPreviewExtension/QuickLookPreviewExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 112;
+				CURRENT_PROJECT_VERSION = 113;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
@@ -1773,7 +1773,7 @@
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.4.2;
+				MARKETING_VERSION = 2.4.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.chocoford.excalidraw.QuickLookPreviewExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;

--- a/ExcalidrawZ.xcodeproj/project.pbxproj
+++ b/ExcalidrawZ.xcodeproj/project.pbxproj
@@ -1028,7 +1028,7 @@
 				CODE_SIGN_ENTITLEMENTS = ExcalidrawZ/ExcalidrawZ.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 109;
+				CURRENT_PROJECT_VERSION = 110;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"ExcalidrawZ/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -1081,7 +1081,7 @@
 				CODE_SIGN_ENTITLEMENTS = ExcalidrawZ/ExcalidrawZ.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 109;
+				CURRENT_PROJECT_VERSION = 110;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"ExcalidrawZ/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -1196,7 +1196,7 @@
 				CODE_SIGN_ENTITLEMENTS = ExcalidrawZ/ExcalidrawZ.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 109;
+				CURRENT_PROJECT_VERSION = 110;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"ExcalidrawZ/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -1249,7 +1249,7 @@
 				CODE_SIGN_ENTITLEMENTS = ExcalidrawZ/ExcalidrawZ.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 109;
+				CURRENT_PROJECT_VERSION = 110;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"ExcalidrawZ/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -1483,7 +1483,7 @@
 				CODE_SIGN_ENTITLEMENTS = ExcalidrawZ/ExcalidrawZ.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 109;
+				CURRENT_PROJECT_VERSION = 110;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"ExcalidrawZ/Preview Content\"";
 				DEVELOPMENT_TEAM = 3XKM749Y3L;
@@ -1543,7 +1543,7 @@
 				CODE_SIGN_ENTITLEMENTS = ExcalidrawZ/ExcalidrawZ.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 109;
+				CURRENT_PROJECT_VERSION = 110;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"ExcalidrawZ/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -1685,7 +1685,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = QuickLookPreviewExtension/QuickLookPreviewExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 109;
+				CURRENT_PROJECT_VERSION = 110;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
@@ -1721,7 +1721,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = QuickLookPreviewExtension/QuickLookPreviewExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 109;
+				CURRENT_PROJECT_VERSION = 110;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
@@ -1756,7 +1756,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = QuickLookPreviewExtension/QuickLookPreviewExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 109;
+				CURRENT_PROJECT_VERSION = 110;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;

--- a/ExcalidrawZ.xcodeproj/project.pbxproj
+++ b/ExcalidrawZ.xcodeproj/project.pbxproj
@@ -1028,7 +1028,7 @@
 				CODE_SIGN_ENTITLEMENTS = ExcalidrawZ/ExcalidrawZ.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 111;
+				CURRENT_PROJECT_VERSION = 112;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"ExcalidrawZ/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -1081,7 +1081,7 @@
 				CODE_SIGN_ENTITLEMENTS = ExcalidrawZ/ExcalidrawZ.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 111;
+				CURRENT_PROJECT_VERSION = 112;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"ExcalidrawZ/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -1196,7 +1196,7 @@
 				CODE_SIGN_ENTITLEMENTS = ExcalidrawZ/ExcalidrawZ.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 111;
+				CURRENT_PROJECT_VERSION = 112;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"ExcalidrawZ/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -1249,7 +1249,7 @@
 				CODE_SIGN_ENTITLEMENTS = ExcalidrawZ/ExcalidrawZ.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 111;
+				CURRENT_PROJECT_VERSION = 112;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"ExcalidrawZ/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -1483,7 +1483,7 @@
 				CODE_SIGN_ENTITLEMENTS = ExcalidrawZ/ExcalidrawZ.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 111;
+				CURRENT_PROJECT_VERSION = 112;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"ExcalidrawZ/Preview Content\"";
 				DEVELOPMENT_TEAM = 3XKM749Y3L;
@@ -1543,7 +1543,7 @@
 				CODE_SIGN_ENTITLEMENTS = ExcalidrawZ/ExcalidrawZ.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 111;
+				CURRENT_PROJECT_VERSION = 112;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"ExcalidrawZ/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -1685,7 +1685,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = QuickLookPreviewExtension/QuickLookPreviewExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 110;
+				CURRENT_PROJECT_VERSION = 112;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
@@ -1702,7 +1702,7 @@
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.4.1;
+				MARKETING_VERSION = 2.4.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.chocoford.excalidraw-Debug.QuickLookPreviewExtension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1721,7 +1721,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = QuickLookPreviewExtension/QuickLookPreviewExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 110;
+				CURRENT_PROJECT_VERSION = 112;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
@@ -1738,7 +1738,7 @@
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.4.1;
+				MARKETING_VERSION = 2.4.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.chocoford.excalidraw.QuickLookPreviewExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1756,7 +1756,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = QuickLookPreviewExtension/QuickLookPreviewExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 110;
+				CURRENT_PROJECT_VERSION = 112;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
@@ -1773,7 +1773,7 @@
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.4.1;
+				MARKETING_VERSION = 2.4.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.chocoford.excalidraw.QuickLookPreviewExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;

--- a/ExcalidrawZ.xcodeproj/project.pbxproj
+++ b/ExcalidrawZ.xcodeproj/project.pbxproj
@@ -1028,7 +1028,7 @@
 				CODE_SIGN_ENTITLEMENTS = ExcalidrawZ/ExcalidrawZ.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 110;
+				CURRENT_PROJECT_VERSION = 111;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"ExcalidrawZ/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -1061,7 +1061,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				LOCALIZED_STRING_SWIFTUI_SUPPORT = NO;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.4.1;
+				MARKETING_VERSION = 2.4.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.chocoford.excalidraw-Debug";
 				PRODUCT_NAME = ExcalidrawZ;
 				SDKROOT = auto;
@@ -1081,7 +1081,7 @@
 				CODE_SIGN_ENTITLEMENTS = ExcalidrawZ/ExcalidrawZ.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 110;
+				CURRENT_PROJECT_VERSION = 111;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"ExcalidrawZ/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -1114,7 +1114,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				LOCALIZED_STRING_SWIFTUI_SUPPORT = NO;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.4.1;
+				MARKETING_VERSION = 2.4.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.chocoford.excalidraw;
 				PRODUCT_NAME = ExcalidrawZ;
 				SDKROOT = auto;
@@ -1196,7 +1196,7 @@
 				CODE_SIGN_ENTITLEMENTS = ExcalidrawZ/ExcalidrawZ.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 110;
+				CURRENT_PROJECT_VERSION = 111;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"ExcalidrawZ/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -1229,7 +1229,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				LOCALIZED_STRING_SWIFTUI_SUPPORT = NO;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.4.1;
+				MARKETING_VERSION = 2.4.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.chocoford.excalidraw;
 				PRODUCT_NAME = ExcalidrawZ;
 				SDKROOT = auto;
@@ -1249,7 +1249,7 @@
 				CODE_SIGN_ENTITLEMENTS = ExcalidrawZ/ExcalidrawZ.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 110;
+				CURRENT_PROJECT_VERSION = 111;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"ExcalidrawZ/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -1289,7 +1289,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				LOCALIZED_STRING_SWIFTUI_SUPPORT = NO;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.4.1;
+				MARKETING_VERSION = 2.4.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.chocoford.excalidraw;
 				PRODUCT_NAME = ExcalidrawZ;
 				SDKROOT = auto;
@@ -1483,7 +1483,7 @@
 				CODE_SIGN_ENTITLEMENTS = ExcalidrawZ/ExcalidrawZ.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 110;
+				CURRENT_PROJECT_VERSION = 111;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"ExcalidrawZ/Preview Content\"";
 				DEVELOPMENT_TEAM = 3XKM749Y3L;
@@ -1524,7 +1524,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				LOCALIZED_STRING_SWIFTUI_SUPPORT = NO;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.4.1;
+				MARKETING_VERSION = 2.4.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.chocoford.excalidraw-Debug";
 				PRODUCT_NAME = ExcalidrawZ;
 				SDKROOT = auto;
@@ -1543,7 +1543,7 @@
 				CODE_SIGN_ENTITLEMENTS = ExcalidrawZ/ExcalidrawZ.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 110;
+				CURRENT_PROJECT_VERSION = 111;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"ExcalidrawZ/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -1583,7 +1583,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				LOCALIZED_STRING_SWIFTUI_SUPPORT = NO;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.4.1;
+				MARKETING_VERSION = 2.4.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.chocoford.excalidraw;
 				PRODUCT_NAME = ExcalidrawZ;
 				SDKROOT = auto;

--- a/ExcalidrawZ/ContentView+/Content+OpenFromURL.swift
+++ b/ExcalidrawZ/ContentView+/Content+OpenFromURL.swift
@@ -84,6 +84,9 @@ struct OpenFromURLModifier: ViewModifier {
             .onOpenURL { url in
                 onOpenURL(url)
             }
+            .onReceive(NotificationCenter.default.publisher(for: .didOpenFromUrls)) { notification in
+                handleOpenFromURLs(notification)
+            }
             .onReceive(NotificationCenter.default.publisher(for: .shouldOpenExternalURL)) { notification in
                 guard let url = notification.object as? URL else { return }
 #if os(macOS)
@@ -133,6 +136,27 @@ struct OpenFromURLModifier: ViewModifier {
     }
     
     // MARK: - Handle OpenURL
+    private func handleOpenFromURLs(_ notification: Notification) {
+        guard let urls = notification.object as? [URL], !urls.isEmpty else {
+            return
+        }
+
+        Task { @MainActor in
+            for url in urls {
+                do {
+                    try await fileState.prepareOpenInPlaceAccess(to: url)
+                } catch {
+                    alertToast(error)
+                }
+            }
+
+            if fileState.currentActiveFile == nil,
+               let firstURL = urls.first(where: fileState.temporaryFiles.contains) {
+                fileState.setActiveFile(.temporaryFile(firstURL))
+            }
+        }
+    }
+
     private func onOpenURL(_ url: URL) {
 #if os(iOS)
         if url.scheme?.hasPrefix("msauth.") == true {
@@ -230,17 +254,36 @@ struct OpenFromURLModifier: ViewModifier {
             return
         }
 
-        // Files handed to the app through open-in-place do not have a saved
-        // LocalFolder bookmark. Retain their security scope for the temporary
-        // workspace before the asynchronous editor load begins.
-        if targetURL == url,
-           !fileState.retainOpenInPlaceAccess(to: url) {
-            alertToast(AppError.urlError(.startAccessingSecurityScopedResourceFailed))
-            return
+        if targetURL == url {
+            Task { @MainActor in
+                do {
+                    try await fileState.prepareOpenInPlaceAccess(to: targetURL)
+                    activateTemporaryFile(
+                        at: targetURL,
+                        imageSendToNewFile: imageSendToNewFile,
+                        context: context
+                    )
+                } catch {
+                    alertToast(error)
+                }
+            }
+        } else {
+            activateTemporaryFile(
+                at: targetURL,
+                imageSendToNewFile: imageSendToNewFile,
+                context: context
+            )
         }
-        
+    }
+
+    private func activateTemporaryFile(
+        at targetURL: URL,
+        imageSendToNewFile: (Data, UTType)?,
+        context: NSManagedObjectContext
+    ) {
+        fileState.registerTemporaryFile(targetURL)
         fileState.setActiveFile(.temporaryFile(targetURL))
-        
+
         if let imageSendToNewFile {
             Task {
                 // Wait for boot
@@ -270,19 +313,20 @@ struct OpenFromURLModifier: ViewModifier {
         }
 
         // save a checkpoint immediately.
-        Task.detached {
+        Task {
             do {
+                let content = try await fileState.readTemporaryFileContent(at: targetURL)
                 try await context.perform {
                     let newCheckpoint = LocalFileCheckpoint(context: context)
                     newCheckpoint.url = targetURL
                     newCheckpoint.updatedAt = .now
-                    newCheckpoint.content = try Data(contentsOf: targetURL)
+                    newCheckpoint.content = content
                     
                     context.insert(newCheckpoint)
                     try context.save()
                 }
             } catch {
-                await alertToast(error)
+                alertToast(error)
             }
         }
     }

--- a/ExcalidrawZ/ContentView+/Detail/Components/FileHomeItemView.swift
+++ b/ExcalidrawZ/ContentView+/Detail/Components/FileHomeItemView.swift
@@ -42,6 +42,17 @@ enum FileHomeItemTransitionPreferenceID {
     }
 }
 
+private struct FileHomeItemTransitionSourceEnabledKey: EnvironmentKey {
+    static let defaultValue = true
+}
+
+extension EnvironmentValues {
+    var fileHomeItemTransitionSourceEnabled: Bool {
+        get { self[FileHomeItemTransitionSourceEnabledKey.self] }
+        set { self[FileHomeItemTransitionSourceEnabledKey.self] = newValue }
+    }
+}
+
 struct FileHomeItemView: View {
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.managedObjectContext) var viewContext
@@ -238,6 +249,7 @@ struct FileHomeItemView: View {
 private struct FileHomeItemContentView: View {
     @Environment(\.containerHorizontalSizeClass) private var containerHorizontalSizeClass
     @Environment(\.colorScheme) var colorScheme
+    @Environment(\.fileHomeItemTransitionSourceEnabled) private var transitionSourceEnabled
 #if os(iOS)
     @Environment(\.editMode) var editMode
 #endif
@@ -323,7 +335,7 @@ private struct FileHomeItemContentView: View {
         .background {
             Color.clear
                 .anchorPreference(key: FileHomeItemPreferenceKey.self, value: .bounds) { value in
-                    fileHomeItemTransitionItemState.sourceFileID == fileID
+                    transitionSourceEnabled && fileHomeItemTransitionItemState.sourceFileID == fileID
                     ? [FileHomeItemTransitionPreferenceID.source(for: fileID): value]
                     : [:]
                 }

--- a/ExcalidrawZ/ContentView+/Detail/Components/FileHomeItemView.swift
+++ b/ExcalidrawZ/ContentView+/Detail/Components/FileHomeItemView.swift
@@ -501,8 +501,14 @@ private extension FileState.ActiveFile {
             case .file(let file):
                 let groupNames = Self.groupPath(for: file.group)
                 return groupNames.isEmpty ? "/" : groupNames.joined(separator: " / ")
-            case .localFile(let url), .temporaryFile(let url):
+            case .localFile(let url):
+                return Self.linkedFolderPath(for: url)
+            case .temporaryFile(let url):
+#if os(iOS)
+                return url.deletingLastPathComponent().lastPathComponent
+#else
                 return Self.abbreviatedPath(url.deletingLastPathComponent())
+#endif
             case .collaborationFile:
                 return String(localizable: .collaborationHomeTitle)
             case .cloudStorageFile(let reference):
@@ -530,6 +536,20 @@ private extension FileState.ActiveFile {
             currentGroup = group.parent
         }
         return names.reversed()
+    }
+
+    static func linkedFolderPath(for fileURL: URL) -> String {
+        let directoryURL = fileURL.deletingLastPathComponent().standardizedFileURL
+        let context = PersistenceController.shared.container.viewContext
+        guard let folder = try? LocalFolder.rootFolder(containing: directoryURL, in: context),
+              let rootURL = folder.filePath.map({
+                  URL(fileURLWithPath: $0, isDirectory: true).standardizedFileURL
+              }) else {
+            return directoryURL.lastPathComponent
+        }
+
+        let relativeComponents = directoryURL.pathComponents.dropFirst(rootURL.pathComponents.count)
+        return ([rootURL.lastPathComponent] + Array(relativeComponents)).joined(separator: " / ")
     }
 
     static func abbreviatedPath(_ directoryURL: URL) -> String {

--- a/ExcalidrawZ/ContentView+/Detail/Components/HomeFolderItemView.swift
+++ b/ExcalidrawZ/ContentView+/Detail/Components/HomeFolderItemView.swift
@@ -18,6 +18,7 @@ struct HomeFolderItemView: View {
     var name: String
     var itemsCount: Int
     var isLoading = false
+    var localFolder: LocalFolder?
     
     @State private var isHovered = false
     
@@ -43,6 +44,9 @@ struct HomeFolderItemView: View {
             }
                    
             Spacer()
+            if let localFolder {
+                LocalFolderAvailabilityIndicator(folder: localFolder)
+            }
             if isLoading {
                 ProgressView()
                     .controlSize(.mini)

--- a/ExcalidrawZ/ContentView+/Detail/Home/CloudStorageFolderFileHomeView.swift
+++ b/ExcalidrawZ/ContentView+/Detail/Home/CloudStorageFolderFileHomeView.swift
@@ -214,7 +214,6 @@ struct CloudStorageFolderFileHomeView: View {
 
             Spacer()
         }
-        .disabled(!documentStore.capabilities(for: folder).contains(.createChildren))
 #if os(iOS)
         .modernButtonStyle(style: .glass, size: .regular, shape: .capsule)
 #else

--- a/ExcalidrawZ/ContentView+/Detail/Home/CompactIOS/CompactBrowseRootView.swift
+++ b/ExcalidrawZ/ContentView+/Detail/Home/CompactIOS/CompactBrowseRootView.swift
@@ -292,6 +292,7 @@ struct CompactBrowseRootView: View {
 }
 
 private struct TemporaryFileBrowseRow: View {
+    @Environment(\.fileHomeItemTransitionSourceEnabled) private var transitionSourceEnabled
     @EnvironmentObject private var fileState: FileState
     @EnvironmentObject private var fileHomeItemTransitionItemState: FileHomeItemTransitionItemState
 
@@ -329,7 +330,7 @@ private struct TemporaryFileBrowseRow: View {
                     key: FileHomeItemPreferenceKey.self,
                     value: .bounds
                 ) { value in
-                    fileHomeItemTransitionItemState.sourceFileID == fileID
+                    transitionSourceEnabled && fileHomeItemTransitionItemState.sourceFileID == fileID
                         ? [FileHomeItemTransitionPreferenceID.source(for: fileID): value]
                         : [:]
                 }
@@ -559,13 +560,11 @@ struct CompactContentMoreMenu<HomeGroup: ExcalidrawGroup>: View {
     
     init(group: HomeGroup) {
         self.group = group
-        self.capability = Set(
-            [
-                .select,
-                .createGroup,
-                .importFiles,
-            ]
-        )
+        var capability: Set<Capability> = [.select, .createGroup]
+        if let group = group as? Group, group.groupType != .trash {
+            capability.insert(.importFiles)
+        }
+        self.capability = capability
     }
     
     init() where HomeGroup == Group {

--- a/ExcalidrawZ/ContentView+/Detail/Home/CompactIOS/CompactCloudStorageBrowserView.swift
+++ b/ExcalidrawZ/ContentView+/Detail/Home/CompactIOS/CompactCloudStorageBrowserView.swift
@@ -197,19 +197,21 @@ struct CompactCloudStorageBrowserView: View {
                         Label(.localizable(.librariesButtonSelect), systemSymbol: .checkmarkCircle)
                     }
 
-                    Button {
-                        newFolderName = documentStore.availableFolderName(in: folder)
-                        isCreateFolderPresented = true
-                    } label: {
-                        Label(
-                            .localizable(.fileHomeButtonCreateNewFolder),
-                            systemSymbol: .folderBadgePlus
-                        )
+                    if documentStore.canCreateFolder(
+                        in: folder,
+                        connections: connections
+                    ) {
+                        Button {
+                            newFolderName = documentStore.availableFolderName(in: folder)
+                            isCreateFolderPresented = true
+                        } label: {
+                            Label(
+                                .localizable(.fileHomeButtonCreateNewFolder),
+                                systemSymbol: .folderBadgePlus
+                            )
+                        }
+                        .disabled(isCreatingFolder)
                     }
-                    .disabled(
-                        isCreatingFolder
-                            || !documentStore.capabilities(for: folder).contains(.createChildren)
-                    )
                 }
 
                 Section {

--- a/ExcalidrawZ/ContentView+/Detail/Home/CompactIOS/CompactExcalidrawHomeView.swift
+++ b/ExcalidrawZ/ContentView+/Detail/Home/CompactIOS/CompactExcalidrawHomeView.swift
@@ -12,6 +12,13 @@ import ChocofordUI
 #if os(iOS)
 @available(iOS 26.0, *)
 struct CompactExcalidrawHomeView: View {
+    private enum HomeTab: Hashable {
+        case recently
+        case collaboration
+        case browse
+        case search
+    }
+
     @EnvironmentObject private var fileState: FileState
     @EnvironmentObject private var layoutState: LayoutState
     @EnvironmentObject private var fileHomeItemTransitionState: FileHomeItemTransitionState
@@ -22,6 +29,7 @@ struct CompactExcalidrawHomeView: View {
 
     @State private var searchText = ""
     @State private var navigationPath: [EditorRoute] = []
+    @State private var selectedTab: HomeTab = .recently
 
     
     var body: some View {
@@ -57,27 +65,55 @@ struct CompactExcalidrawHomeView: View {
                 }
             }
             
-            TabView {
-                Tab(.localizable(.compactRecentlyTitle), systemImage: SFSymbol.clockFill.rawValue) {
+            TabView(selection: $selectedTab) {
+                Tab(
+                    .localizable(.compactRecentlyTitle),
+                    systemImage: SFSymbol.clockFill.rawValue,
+                    value: HomeTab.recently
+                ) {
                     CompactRecentlyView()
+                        .environment(
+                            \.fileHomeItemTransitionSourceEnabled,
+                            selectedTab == .recently
+                        )
                         .onAppear {
                             fileState.currentActiveGroup = nil
                         }
                 }
-                Tab(.localizable(.collaborationHomeTitle), systemImage: SFSymbol.person3Fill.rawValue) {
+                Tab(
+                    .localizable(.collaborationHomeTitle),
+                    systemImage: SFSymbol.person3Fill.rawValue,
+                    value: HomeTab.collaboration
+                ) {
                     CompactCollaborationHomeView()
+                        .environment(
+                            \.fileHomeItemTransitionSourceEnabled,
+                            selectedTab == .collaboration
+                        )
                         .onAppear {
                             fileState.currentActiveGroup = .collaboration
                         }
                 }
-                Tab(.localizable(.compactBrowserTitle), systemImage: SFSymbol.folderFill.rawValue) {
+                Tab(
+                    .localizable(.compactBrowserTitle),
+                    systemImage: SFSymbol.folderFill.rawValue,
+                    value: HomeTab.browse
+                ) {
                     CompactBrowseRootView()
+                        .environment(
+                            \.fileHomeItemTransitionSourceEnabled,
+                            selectedTab == .browse
+                        )
                         .onAppear {
                             fileState.currentActiveGroup = nil
                         }
                 }
-                Tab(role: .search) {
+                Tab(value: HomeTab.search, role: .search) {
                     CompactSearchFilesView()
+                        .environment(
+                            \.fileHomeItemTransitionSourceEnabled,
+                            selectedTab == .search
+                        )
                         .onAppear {
                             fileState.currentActiveGroup = nil
                         }

--- a/ExcalidrawZ/ContentView+/Detail/Home/CompactIOS/components/CompactFolderItemView.swift
+++ b/ExcalidrawZ/ContentView+/Detail/Home/CompactIOS/components/CompactFolderItemView.swift
@@ -19,12 +19,14 @@ struct CompactFolderItemView: View {
     var name: String
     var type: Group.GroupType
     var itemsCount: Int
+    var localFolder: LocalFolder?
     
     init<HomeGroup: ExcalidrawGroup>(group: HomeGroup) {
         self.objectID = group.objectID
         self.name = group.name ?? String(localizable: .generalUntitled)
         self.type = group.groupType
         self.itemsCount = group.filesCount + group.subgroupsCount
+        self.localFolder = group as? LocalFolder
     }
 
     init(
@@ -37,6 +39,7 @@ struct CompactFolderItemView: View {
         self.name = name
         self.type = type
         self.itemsCount = itemsCount
+        self.localFolder = nil
     }
     
     var isSelected: Bool {
@@ -66,6 +69,12 @@ struct CompactFolderItemView: View {
                                 .animation(.default, value: isSelected)
                         }
                     }
+            }
+        }
+        .overlay(alignment: .topTrailing) {
+            if let localFolder {
+                LocalFolderAvailabilityIndicator(folder: localFolder)
+                    .padding(8)
             }
         }
         .simultaneousGesture(TapGesture().onEnded { _ in

--- a/ExcalidrawZ/ContentView+/Detail/Home/FileHomeView.swift
+++ b/ExcalidrawZ/ContentView+/Detail/Home/FileHomeView.swift
@@ -293,6 +293,7 @@ struct FileHomeView<HomeGroup: ExcalidrawGroup>: View {
     @State private var contentHeight: CGFloat = 0
     
     @State private var isCreateGroupDialogPresented: Bool = false
+    @State private var isImportFilesDialogPresented = false
     
 #if os(iOS)
     @State private var editMode: EditMode = .inactive
@@ -466,17 +467,17 @@ struct FileHomeView<HomeGroup: ExcalidrawGroup>: View {
                             }
                         }
 #endif
-                        
+
                         GroupMenuItems(
                             group: group,
-                            canExpand: false
-                        ) {
-                            triggers.onToggleRename()
-                        } onToogleCreateSubfolder: {
-                            triggers.onToogleCreateSubfolder()
-                        } onToggleDelete: {
-                            triggers.onToggleDelete()
-                        }
+                            canExpand: false,
+                            onToggleRename: triggers.onToggleRename,
+                            onToogleCreateSubfolder: triggers.onToogleCreateSubfolder,
+                            onToggleDelete: triggers.onToggleDelete,
+                            onImportFiles: group.groupType == .trash
+                                ? nil
+                                : { isImportFilesDialogPresented.toggle() }
+                        )
                     } label: {
 #if os(iOS)
                         Label(
@@ -489,6 +490,7 @@ struct FileHomeView<HomeGroup: ExcalidrawGroup>: View {
 #endif
                     }
                 }
+                .modifier(ImportFilesModifier(isPresented: $isImportFilesDialogPresented))
             } else if let folder = group as? LocalFolder {
                 LocalFolderMenuProvider(folder: folder) { triggers in
                     Menu {

--- a/ExcalidrawZ/ContentView+/Detail/Home/FileHomeView.swift
+++ b/ExcalidrawZ/ContentView+/Detail/Home/FileHomeView.swift
@@ -588,6 +588,7 @@ struct FileHomeView<HomeGroup: ExcalidrawGroup>: View {
                         }(),
                         name: group.name ?? String(localizable: .generalUntitled),
                         itemsCount: group.filesCount + group.subgroupsCount,
+                        localFolder: group as? LocalFolder
                     )
                     .modifier(FileHomeGroupContextMenuModifier(group: group))
                     .simultaneousGesture(TapGesture(count: 2).onEnded {

--- a/ExcalidrawZ/ContentView.swift
+++ b/ExcalidrawZ/ContentView.swift
@@ -95,9 +95,6 @@ struct ContentView: View {
             }
 #endif
             .containerSizeClassInjection()
-            .onReceive(NotificationCenter.default.publisher(for: .didOpenFromUrls)) { notification in
-                handleOpenFromURLs(notification)
-            }
             .onReceive(NotificationCenter.default.publisher(for: .toggleSidebar)) { notification in
                 handleToggleSidebar(notification)
             }
@@ -213,18 +210,6 @@ struct ContentView: View {
             ContentViewModern()
         } else {
             ContentViewLagacy()
-        }
-    }
-    
-    private func handleOpenFromURLs(_ notification: Notification) {
-        if let urls = notification.object as? [URL], !urls.isEmpty {
-            fileState.temporaryFiles.append(contentsOf: urls)
-            fileState.temporaryFiles = Array(Set(fileState.temporaryFiles))
-            if fileState.currentActiveFile == nil || fileState.currentActiveGroup != .temporary {
-                fileState.setActiveFile(
-                    .localFile(fileState.temporaryFiles.first!)
-                )
-            }
         }
     }
     

--- a/ExcalidrawZ/ExcalidrawView/Editor/ExcalidrawEditor.swift
+++ b/ExcalidrawZ/ExcalidrawView/Editor/ExcalidrawEditor.swift
@@ -716,7 +716,7 @@ struct ExcalidrawEditor: View {
                     }
 
                 case .temporaryFile(let url):
-                    let data = try await FileSyncCoordinator.shared.openFile(url)
+                    let data = try await fileState.readTemporaryFileContent(at: url)
                     let file = try ExcalidrawFile(data: data, id: activeFile.id)
                     await MainActor.run {
                         guard self.activeFile?.id == activeFile.id else { return }
@@ -1192,7 +1192,8 @@ struct ExcalidrawEditor: View {
                 logger.debug("Persisting temporary canvas update id=\(file.id) url=\(url.lastPathComponent) elements=\(file.elements.count)")
                 Task {
                     do {
-                        let oldFile = try ExcalidrawFile(contentsOf: url)
+                        let oldContent = try await fileState.readTemporaryFileContent(at: url)
+                        let oldFile = try ExcalidrawFile(data: oldContent, id: file.id)
                         if !hasPersistentCanvasChanges(in: file, comparedTo: oldFile) {
                             return
                         }

--- a/ExcalidrawZ/ExcalidrawView/Editor/ExcalidrawEditor.swift
+++ b/ExcalidrawZ/ExcalidrawView/Editor/ExcalidrawEditor.swift
@@ -123,6 +123,15 @@ struct ExcalidrawEditor: View {
         }
     }
 
+    /// Collaboration rooms own their WebView and live synchronization. Feeding
+    /// their iCloud snapshot through the normal editor reload path can interrupt
+    /// the room while it is connecting.
+    private var externallyObservedDocument: FileState.ActiveFile? {
+        guard let activeFile else { return nil }
+        guard case .collaborationFile = activeFile else { return activeFile }
+        return nil
+    }
+
     private var usesCompactIOSAIChatSurfaces: Bool {
 #if os(iOS)
         ExcalidrawToolbarLayoutPolicy.usesCompactIOSBottomToolbar(
@@ -219,6 +228,7 @@ struct ExcalidrawEditor: View {
                 .excalidrawEditorOverlays(
                     loadingState: $canvasLoadingState,
                     hasFile: localFileBinding.wrappedValue != nil,
+                    fileID: activeFile?.id,
                     keepsLoadingCoverPresented: isCloudStorageConflictBlockingEditor
                 )
                 .opacity(isInCollaborationSpace ? 0 : 1)
@@ -328,7 +338,7 @@ struct ExcalidrawEditor: View {
             )
         }
         .observeExcalidrawFileStatus(
-            for: activeFile,
+            for: externallyObservedDocument,
             activeFileLockState: lockedContentState.activeFileLockState,
             conflictFileURL: $conflictFileURL,
         ) { latestData, onDone in
@@ -344,7 +354,7 @@ struct ExcalidrawEditor: View {
         }
 #if os(iOS)
         .applyIOSAutoSync(
-            activeFile: activeFile,
+            activeFile: externallyObservedDocument,
             activeFileLockState: lockedContentState.activeFileLockState,
             localFileBinding: localFileBinding
         ) { latestData in
@@ -371,6 +381,7 @@ struct ExcalidrawEditor: View {
             cloudStorageRefreshTask?.cancel()
             cloudStorageRefreshTask = nil
             cloudStorageRefreshTaskID = nil
+            cancelPendingCloudUpdate()
             prepareCanvasLoadingPresentation(for: newFile)
             isCloudStorageConflictBlockingEditor = false
             loadingTask = Task {
@@ -481,6 +492,7 @@ struct ExcalidrawEditor: View {
         .onDisappear {
             recordVisitTask?.cancel()
             recordVisitTask = nil
+            cancelPendingCloudUpdate()
             cloudStorageRefreshTask?.cancel()
             cloudStorageRefreshTask = nil
             cloudStorageRefreshTaskID = nil
@@ -983,6 +995,10 @@ struct ExcalidrawEditor: View {
     }
     
     private func handleLatestData(_ latestData: Data) {
+        guard let targetFileID = externallyObservedDocument?.id else {
+            logger.debug("Ignored external document update outside the normal editor")
+            return
+        }
         guard lockedContentState.activeFileLockState != .locked else {
             logger.info("Ignored cloud update while active file is locked")
             return
@@ -999,12 +1015,16 @@ struct ExcalidrawEditor: View {
             // User is idle, apply cloud update immediately
             logger.info("User idle, applying cloud update immediately")
             cloudSyncTask?.cancel()  // Cancel any pending task
+            latestCloudData = nil
             isSyncing = true
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
                 isSyncing = false
             }
-            Task {
-                await pullUpdatingFromCloud(latestData: latestData)
+            cloudSyncTask = Task {
+                await pullUpdatingFromCloud(
+                    latestData: latestData,
+                    expectedFileID: targetFileID
+                )
             }
         } else {
             // User is actively editing, defer cloud update and wait for idle
@@ -1027,13 +1047,15 @@ struct ExcalidrawEditor: View {
                     await MainActor.run {
                         self.logger.info("Wait task: User became idle, applying deferred cloud update")
                         self.latestCloudData = nil
-                        self.cloudSyncTask = nil
                         self.isSyncing = true
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
                             self.isSyncing = false
                         }
                     }
-                    await pullUpdatingFromCloud(latestData: stillCloudData)
+                    await pullUpdatingFromCloud(
+                        latestData: stillCloudData,
+                        expectedFileID: targetFileID
+                    )
                 } else {
                     await MainActor.run {
                         self.cloudSyncTask = nil
@@ -1041,6 +1063,13 @@ struct ExcalidrawEditor: View {
                 }
             }
         }
+    }
+
+    private func cancelPendingCloudUpdate() {
+        cloudSyncTask?.cancel()
+        cloudSyncTask = nil
+        latestCloudData = nil
+        isSyncing = false
     }
 
     private func latestLocalCanvasEditTime() -> Date? {
@@ -1057,7 +1086,19 @@ struct ExcalidrawEditor: View {
         }
     }
 
-    private func pullUpdatingFromCloud(latestData: Data) async {
+    private func pullUpdatingFromCloud(
+        latestData: Data,
+        expectedFileID: String? = nil
+    ) async {
+        guard let targetFile = externallyObservedDocument else {
+            logger.debug("Skipped cloud pull outside the normal editor")
+            return
+        }
+        let targetFileID = expectedFileID ?? targetFile.id
+        guard targetFile.id == targetFileID else {
+            logger.debug("Skipped stale cloud pull target=\(targetFileID) active=\(targetFile.id)")
+            return
+        }
         guard lockedContentState.activeFileLockState != .locked else {
             self.logger.info("Skipped cloud pull while active file is locked")
             return
@@ -1066,24 +1107,33 @@ struct ExcalidrawEditor: View {
         self.logger.info("pullUpdatingFromCloud")
         do {
             let data: Data
-            if let activeFile,
-               case .file = activeFile,
-               let fileID = excalidrawFile?.id {
+            if case .file = targetFile {
                 data = try await ExcalidrawViewportStateStore.shared
                     .contentDataByApplyingStoredViewport(
                         to: latestData,
-                        fileID: fileID
+                        fileID: targetFileID
                     )
             } else {
                 data = latestData
             }
-            let file = try ExcalidrawFile(data: data, id: excalidrawFile?.id)
+            guard !Task.isCancelled else { return }
+            let file = try ExcalidrawFile(data: data, id: targetFileID)
             await MainActor.run {
+                guard !Task.isCancelled,
+                      self.externallyObservedDocument?.id == targetFileID else { return }
+                if let currentFile = self.excalidrawFile,
+                   !self.hasPersistentCanvasChanges(in: file, comparedTo: currentFile) {
+                    self.logger.debug("Ignored duplicate cloud document update id=\(targetFileID)")
+                    return
+                }
                 self.applyFileToEditorAndForceReload(file)
             }
         } catch {
+            guard !Task.isCancelled,
+                  externallyObservedDocument?.id == targetFileID else { return }
             alertToast(error)
             await MainActor.run {
+                guard self.externallyObservedDocument?.id == targetFileID else { return }
                 self.excalidrawFile = nil
             }
         }
@@ -1106,7 +1156,7 @@ struct ExcalidrawEditor: View {
         excalidrawFile = file
         NotificationCenter.default.post(
             name: .forceReloadExcalidrawFile,
-            object: nil
+            object: file.id
         )
     }
 

--- a/ExcalidrawZ/ExcalidrawView/Editor/ExcalidrawEditor.swift
+++ b/ExcalidrawZ/ExcalidrawView/Editor/ExcalidrawEditor.swift
@@ -1217,11 +1217,10 @@ struct ExcalidrawEditor: View {
                 return .accepted
 
             case .localFile(let url):
-                guard case .localFolder(let folder) = fileState.currentActiveGroup else { return .rejected }
                 logger.debug("Persisting local canvas update id=\(file.id) url=\(url.lastPathComponent) elements=\(file.elements.count)")
                 Task {
                     do {
-                        try await folder.withSecurityScopedURL { _ in
+                        try await LocalFolder.withSecurityScopedAccessToContainingFolder(for: url) {
                             let oldFile = try ExcalidrawFile(contentsOf: url)
                             if !hasPersistentCanvasChanges(in: file, comparedTo: oldFile) {
                                 return

--- a/ExcalidrawZ/ExcalidrawView/Editor/ExcalidrawEditorOverlayModifier.swift
+++ b/ExcalidrawZ/ExcalidrawView/Editor/ExcalidrawEditorOverlayModifier.swift
@@ -27,6 +27,7 @@ struct ExcalidrawEditorOverlayModifier: ViewModifier {
 
     @Binding var loadingState: ExcalidrawCanvasView.LoadingState
     var hasFile: Bool
+    var fileID: String?
     var keepsLoadingCoverPresented: Bool = false
 
     @State private var isLoadingOverlayPresented = false
@@ -129,7 +130,7 @@ struct ExcalidrawEditorOverlayModifier: ViewModifier {
             Button {
                 NotificationCenter.default.post(
                     name: .forceReloadExcalidrawFile,
-                    object: nil
+                    object: fileID
                 )
             } label: {
                 Label(.localizable(.generalButtonRetry), systemSymbol: .arrowClockwise)
@@ -411,11 +412,13 @@ extension View {
     func excalidrawEditorOverlays(
         loadingState: Binding<ExcalidrawCanvasView.LoadingState>,
         hasFile: Bool,
+        fileID: String?,
         keepsLoadingCoverPresented: Bool = false
     ) -> some View {
         modifier(ExcalidrawEditorOverlayModifier(
             loadingState: loadingState,
             hasFile: hasFile,
+            fileID: fileID,
             keepsLoadingCoverPresented: keepsLoadingCoverPresented
         ))
     }

--- a/ExcalidrawZ/ExcalidrawView/Engine/ExcalidrawCanvasView.swift
+++ b/ExcalidrawZ/ExcalidrawView/Engine/ExcalidrawCanvasView.swift
@@ -120,7 +120,9 @@ struct ExcalidrawCanvasView: View {
 #endif
             .onReceive(
                 NotificationCenter.default.publisher(for: .forceReloadExcalidrawFile)
-            ) { _ in
+            ) { notification in
+                guard let targetFileID = notification.object as? String,
+                      file?.id == targetFileID else { return }
                 let targetFile = file
                 Task {
                     await excalidrawCore.documentSyncController.load(targetFile, force: true)

--- a/ExcalidrawZ/ExcalidrawView/Engine/ExcalidrawCore/ExcalidrawCore.swift
+++ b/ExcalidrawZ/ExcalidrawView/Engine/ExcalidrawCore/ExcalidrawCore.swift
@@ -279,12 +279,16 @@ extension ExcalidrawCore {
         var didLogWait = false
 
         while true {
-            let coreLoading = self.isLoading || self.isNavigating || !self.isDocumentLoaded
+            // Collaboration keeps `isLoading` true until the room opens. A new room,
+            // however, must load its initial document before `openCollabMode()` runs.
+            // Document readiness therefore depends only on WebView navigation and the
+            // JS onload signal, not on the broader loading state used by the UI.
+            let documentLoading = self.isNavigating || !self.isDocumentLoaded
             let webLoading = await self.webView.isLoading
             let initialMediaLoading = parent != nil
                 && !hasInjectIndexedDBData
 
-            if !coreLoading && !webLoading && !initialMediaLoading {
+            if !documentLoading && !webLoading && !initialMediaLoading {
                 return true
             }
 
@@ -293,14 +297,14 @@ extension ExcalidrawCore {
             }
 
             if Date() >= deadline {
-                if !coreLoading && !webLoading && initialMediaLoading {
+                if !documentLoading && !webLoading && initialMediaLoading {
                     logger.warning(
                         "Timed out waiting for initial media injection before loading file \(fileID); continuing with available media"
                     )
                     return true
                 }
                 logger.warning(
-                    "Timed out waiting to load file \(fileID). coreLoading=\(coreLoading) webLoading=\(webLoading) initialMediaLoading=\(initialMediaLoading)"
+                    "Timed out waiting to load file \(fileID). documentLoading=\(documentLoading) webLoading=\(webLoading) initialMediaLoading=\(initialMediaLoading)"
                 )
                 return false
             }

--- a/ExcalidrawZ/ExcalidrawView/Engine/ExcalidrawCore/Helpers/ExcalidrawCore+NativeEyeDropper.swift
+++ b/ExcalidrawZ/ExcalidrawView/Engine/ExcalidrawCore/Helpers/ExcalidrawCore+NativeEyeDropper.swift
@@ -86,21 +86,17 @@ final class ExcalidrawNativeEyeDropperCoordinator: NSObject {
 #if os(macOS)
         let sampler = NSColorSampler()
         colorSampler = sampler
-        sampler.show { [weak self] color in
-            Task { @MainActor in
-                guard let self,
-                      self.activeRequest?.requestId == request.requestId else {
-                    return
-                }
-                self.colorSampler = nil
-                guard let color,
-                      let hex = Self.sRGBHex(color) else {
-                    await self.complete(.cancelled(requestId: request.requestId))
-                    return
-                }
-                await self.complete(.selected(requestId: request.requestId, color: hex))
-            }
+        let color = await sampler.sample()
+        guard activeRequest?.requestId == request.requestId else {
+            return
         }
+        colorSampler = nil
+        guard let color,
+              let hex = Self.sRGBHex(color) else {
+            await complete(.cancelled(requestId: request.requestId))
+            return
+        }
+        await complete(.selected(requestId: request.requestId, color: hex))
 #elseif os(iOS)
         guard let presenter = presentationViewController() else {
             core?.logger.warning("Unable to present native eye dropper without an active view controller")

--- a/ExcalidrawZ/ExcalidrawView/components/FileCoverCacheCoordinator.swift
+++ b/ExcalidrawZ/ExcalidrawView/components/FileCoverCacheCoordinator.swift
@@ -634,7 +634,12 @@ final class FileCoverCacheCoordinator: ObservableObject {
 
                         case .temporaryFile(let url):
                             mediaHydrationFileObjectID = nil
-                            excalidrawFile = try ExcalidrawFile(contentsOf: url)
+                            guard let fileState else { return .retry }
+                            let content = try await fileState.readTemporaryFileContent(at: url)
+                            excalidrawFile = try ExcalidrawFile(
+                                data: content,
+                                id: activeFile.id
+                            )
 
                         case .collaborationFile(let collaborationFile):
                             mediaHydrationFileObjectID = nil

--- a/ExcalidrawZ/Extensions/URL+Extension.swift
+++ b/ExcalidrawZ/Extensions/URL+Extension.swift
@@ -24,4 +24,14 @@ extension URL {
         guard !relativePath.isEmpty else { return newRootURL.standardizedFileURL }
         return newRootURL.standardizedFileURL.appendingPathComponent(relativePath)
     }
+
+    func hasSameFileSystemPath(as other: URL) -> Bool {
+        standardizedFileURL.path == other.standardizedFileURL.path
+    }
+
+    func isContained(in directoryURL: URL) -> Bool {
+        let path = standardizedFileURL.path
+        let directoryPath = directoryURL.standardizedFileURL.path
+        return path == directoryPath || path.hasPrefix(directoryPath + "/")
+    }
 }

--- a/ExcalidrawZ/Localizable.xcstrings
+++ b/ExcalidrawZ/Localizable.xcstrings
@@ -137993,6 +137993,52 @@
         }
       }
     },
+    "whatsNewCloudStorageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "اربط OneDrive وDropbox وخدمات WebDAV لتصفح ملفات Excalidraw وتحريرها والحفاظ على مزامنتها." } },
+        "de": { "stringUnit": { "state": "translated", "value": "Verbinde OneDrive, Dropbox und WebDAV-Dienste, um Excalidraw-Dateien zu durchsuchen, zu bearbeiten und zu synchronisieren." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Connect OneDrive, Dropbox, and WebDAV services to browse, edit, and keep your Excalidraw files in sync." } },
+        "es": { "stringUnit": { "state": "translated", "value": "Conecta OneDrive, Dropbox y servicios WebDAV para explorar, editar y mantener sincronizados tus archivos de Excalidraw." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Connectez OneDrive, Dropbox et des services WebDAV pour parcourir, modifier et synchroniser vos fichiers Excalidraw." } },
+        "hi": { "stringUnit": { "state": "translated", "value": "Excalidraw फ़ाइलें ब्राउज़, संपादित और सिंक रखने के लिए OneDrive, Dropbox और WebDAV सेवाएँ कनेक्ट करें।" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Connetti OneDrive, Dropbox e servizi WebDAV per sfogliare, modificare e sincronizzare i file Excalidraw." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "OneDrive、Dropbox、WebDAVサービスに接続し、Excalidrawファイルを参照、編集、同期できます。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "OneDrive, Dropbox 및 WebDAV 서비스를 연결하여 Excalidraw 파일을 탐색, 편집 및 동기화하세요." } },
+        "nl": { "stringUnit": { "state": "translated", "value": "Verbind OneDrive, Dropbox en WebDAV-diensten om Excalidraw-bestanden te bekijken, bewerken en synchroniseren." } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Połącz OneDrive, Dropbox i usługi WebDAV, aby przeglądać, edytować i synchronizować pliki Excalidraw." } },
+        "pt": { "stringUnit": { "state": "translated", "value": "Conecte OneDrive, Dropbox e serviços WebDAV para navegar, editar e manter seus arquivos do Excalidraw sincronizados." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Подключайте OneDrive, Dropbox и сервисы WebDAV, чтобы просматривать, редактировать и синхронизировать файлы Excalidraw." } },
+        "th": { "stringUnit": { "state": "translated", "value": "เชื่อมต่อ OneDrive, Dropbox และบริการ WebDAV เพื่อเรียกดู แก้ไข และซิงค์ไฟล์ Excalidraw ของคุณ" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "Excalidraw dosyalarınıza göz atmak, düzenlemek ve eşitlemek için OneDrive, Dropbox ve WebDAV hizmetlerini bağlayın." } },
+        "vi": { "stringUnit": { "state": "translated", "value": "Kết nối OneDrive, Dropbox và các dịch vụ WebDAV để duyệt, chỉnh sửa và đồng bộ tệp Excalidraw." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "连接 OneDrive、Dropbox 和 WebDAV 服务，浏览、编辑并同步你的 Excalidraw 文件。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "連接 OneDrive、Dropbox 和 WebDAV 服務，瀏覽、編輯並同步你的 Excalidraw 檔案。" } }
+      }
+    },
+    "whatsNewCloudStorageTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "التخزين السحابي" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Cloud-Speicher" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Cloud Storage" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Almacenamiento en la nube" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Stockage cloud" } },
+        "hi": { "stringUnit": { "state": "translated", "value": "क्लाउड स्टोरेज" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Archiviazione cloud" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "クラウドストレージ" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "클라우드 저장소" } },
+        "nl": { "stringUnit": { "state": "translated", "value": "Cloudopslag" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Pamięć w chmurze" } },
+        "pt": { "stringUnit": { "state": "translated", "value": "Armazenamento em nuvem" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Облачное хранилище" } },
+        "th": { "stringUnit": { "state": "translated", "value": "พื้นที่จัดเก็บบนคลาวด์" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "Bulut Depolama" } },
+        "vi": { "stringUnit": { "state": "translated", "value": "Lưu trữ đám mây" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "云存储" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "雲端儲存空間" } }
+      }
+    },
     "whatsNewDropboxDescription": {
       "extractionState": "manual",
       "localizations": {
@@ -138037,6 +138083,52 @@
         "vi": { "stringUnit": { "state": "translated", "value": "Liên kết thư mục Google Drive để quản lý tệp Excalidraw trên các thiết bị." } },
         "zh-Hans": { "stringUnit": { "state": "translated", "value": "关联 Google Drive 文件夹，在不同设备间管理 Excalidraw 文件。" } },
         "zh-Hant": { "stringUnit": { "state": "translated", "value": "連結 Google Drive 資料夾，在不同裝置間管理 Excalidraw 檔案。" } }
+      }
+    },
+    "whatsNewNativeColorPickerDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "اختر الألوان من أي مكان على الشاشة باستخدام أداة القطّارة الأصلية على Mac وiPad وiPhone." } },
+        "de": { "stringUnit": { "state": "translated", "value": "Wähle Farben mit der systemeigenen Pipette direkt vom Bildschirm auf Mac, iPad und iPhone aus." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Pick colors from anywhere on screen with the native eyedropper on Mac, iPad, and iPhone." } },
+        "es": { "stringUnit": { "state": "translated", "value": "Elige colores de cualquier parte de la pantalla con el cuentagotas nativo en Mac, iPad y iPhone." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Prélevez des couleurs n'importe où à l'écran avec la pipette native sur Mac, iPad et iPhone." } },
+        "hi": { "stringUnit": { "state": "translated", "value": "Mac, iPad और iPhone पर नेटिव आईड्रॉपर से स्क्रीन पर कहीं से भी रंग चुनें।" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Scegli i colori da qualsiasi punto dello schermo con il contagocce nativo su Mac, iPad e iPhone." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "Mac、iPad、iPhoneのネイティブスポイトで、画面上のどこからでも色を選択できます。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "Mac, iPad 및 iPhone의 기본 스포이트로 화면 어디에서나 색상을 선택하세요." } },
+        "nl": { "stringUnit": { "state": "translated", "value": "Kies kleuren overal op het scherm met de systeemeigen pipet op Mac, iPad en iPhone." } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Pobieraj kolory z dowolnego miejsca na ekranie za pomocą systemowej pipety na Macu, iPadzie i iPhonie." } },
+        "pt": { "stringUnit": { "state": "translated", "value": "Escolha cores em qualquer lugar da tela com o conta-gotas nativo no Mac, iPad e iPhone." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Выбирайте цвета в любой точке экрана с помощью системной пипетки на Mac, iPad и iPhone." } },
+        "th": { "stringUnit": { "state": "translated", "value": "เลือกสีจากที่ใดก็ได้บนหน้าจอด้วยเครื่องมือดูดสีของระบบบน Mac, iPad และ iPhone" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "Mac, iPad ve iPhone'daki yerel damlalıkla ekranın herhangi bir yerinden renk seçin." } },
+        "vi": { "stringUnit": { "state": "translated", "value": "Chọn màu ở bất kỳ đâu trên màn hình bằng công cụ hút màu hệ thống trên Mac, iPad và iPhone." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "使用系统原生吸管，直接从 Mac、iPad 和 iPhone 屏幕的任意位置选取颜色。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "使用系統原生滴管，直接從 Mac、iPad 和 iPhone 螢幕的任意位置選取顏色。" } }
+      }
+    },
+    "whatsNewNativeColorPickerTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "منتقي الألوان الأصلي" } },
+        "de": { "stringUnit": { "state": "translated", "value": "System-Farbwähler" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Native Color Picker" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Selector de color nativo" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Sélecteur de couleurs natif" } },
+        "hi": { "stringUnit": { "state": "translated", "value": "नेटिव रंग चयनकर्ता" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Selettore colore nativo" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "ネイティブカラーピッカー" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "기본 색상 선택기" } },
+        "nl": { "stringUnit": { "state": "translated", "value": "Systeemkleurkiezer" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Systemowy próbnik kolorów" } },
+        "pt": { "stringUnit": { "state": "translated", "value": "Seletor de cores nativo" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Системная пипетка" } },
+        "th": { "stringUnit": { "state": "translated", "value": "ตัวเลือกสีของระบบ" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "Yerel Renk Seçici" } },
+        "vi": { "stringUnit": { "state": "translated", "value": "Bộ chọn màu hệ thống" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "原生取色器" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "原生取色器" } }
       }
     },
     "whatsNewOneDriveDescription": {

--- a/ExcalidrawZ/Localizable.xcstrings
+++ b/ExcalidrawZ/Localizable.xcstrings
@@ -100474,6 +100474,684 @@
         }
       }
     },
+    "settingsCloudStorageDisconnectAction": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnect"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "断开连接"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "斷開連接"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قطع الاتصال"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trennen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconectar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déconnecter"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अलग करें"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnetti"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切断"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연결 해제"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ontkoppelen"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozłącz"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconectar"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отключить"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัดการเชื่อมต่อ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bağlantıyı Kes"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ngắt kết nối"
+          }
+        }
+      }
+    },
+    "settingsCloudStorageDisconnectDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnecting removes this account, its linked folders, and local caches from ExcalidrawZ. Files stored in the cloud are not deleted."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "断开连接将从 ExcalidrawZ 中移除此帐户、其链接文件夹以及本地缓存。存储在云中的文件不会被删除。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "斷開連接將移除此帳戶、其鏈接的資料夾和本地緩存從 ExcalidrawZ 中。存儲在雲端的文件不會被刪除。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قطع الاتصال يزيل هذا الحساب والمجلدات المرتبطة به والذاكرة المؤقتة المحلية من ExcalidrawZ. الملفات المخزنة في السحابة لن تُحذف."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Trennen entfernt dieses Konto, seine verlinkten Ordner und lokale Caches von ExcalidrawZ. In der Cloud gespeicherte Dateien werden nicht gelöscht."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconectar elimina esta cuenta, sus carpetas vinculadas y las cachés locales de ExcalidrawZ. Los archivos almacenados en la nube no se eliminan."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La déconnexion supprime ce compte, ses dossiers liés et les caches locaux d'ExcalidrawZ. Les fichiers stockés dans le cloud ne sont pas supprimés."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अलग करने से इस खाते, इसके लिंक किए गए फ़ोल्डर्स और स्थानीय कैश को ExcalidrawZ से हटा दिया जाएगा। क्लाउड में संग्रहीत फ़ाइलें मिटाई नहीं जाएंगी।"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La disconnessione rimuove questo account, le sue cartelle collegate e le cache locali da ExcalidrawZ. I file memorizzati nel cloud non vengono eliminati."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切断すると、このアカウント、そのリンクされたフォルダー、そしてローカルキャッシュがExcalidrawZから削除されます。クラウドに保存されているファイルは削除されません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연결 해제를 통해 이 계정, 연결된 폴더 및 ExcalidrawZ의 로컬 캐시가 제거됩니다. 클라우드에 저장된 파일은 삭제되지 않습니다."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Het ontkoppelen verwijdert dit account, de gekoppelde mappen en lokale caches van ExcalidrawZ. Bestanden die in de cloud zijn opgeslagen, worden niet verwijderd."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozłączenie usunie to konto, powiązane foldery i lokalne pamięci podręczne z ExcalidrawZ. Pliki przechowywane w chmurze nie zostaną usunięte."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconectar remove esta conta, suas pastas vinculadas e caches locais do ExcalidrawZ. Os arquivos armazenados na nuvem não serão excluídos."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отключение удаляет эту учетную запись, связанные папки и локальные кэши из ExcalidrawZ. Файлы, хранящиеся в облаке, не удаляются."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การตัดการเชื่อมต่อจะลบบัญชีนี้ โฟลเดอร์ที่เชื่อมโยง และแคชในเครื่องออกจาก ExcalidrawZ ไฟล์ที่จัดเก็บในคลาวด์จะไม่ถูกลบ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bağlantıyı kesmek, bu hesabı, bağlı klasörlerini ve ExcalidrawZ'deki yerel önbellekleri kaldırır. Bulutta depolanan dosyalar silinmez."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Việc ngắt kết nối sẽ xóa tài khoản này, các thư mục liên kết của nó và bộ nhớ cache cục bộ khỏi ExcalidrawZ. Các tệp lưu trữ trên đám mây sẽ không bị xóa."
+          }
+        }
+      }
+    },
+    "settingsCloudStorageDisconnectMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnect %@ from %@? All linked folders for this account will be removed from ExcalidrawZ."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从 %@ 断开连接 %@？此帐户的所有链接文件夹将从 ExcalidrawZ 中移除。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確定要從 %@ 斷開連接 %@ 嗎？此帳戶的所有鏈接資料夾將從 ExcalidrawZ 中移除。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قطع الاتصال %@ من %@؟ سوف تُزال جميع المجلدات المرتبطة بهذا الحساب من ExcalidrawZ."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konto %@ von %@ trennen? Alle verlinkten Ordner für dieses Konto werden von ExcalidrawZ entfernt."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Desconectar %@ de %@? Todas las carpetas vinculadas a esta cuenta serán eliminadas de ExcalidrawZ."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déconnecter %@ de %@ ? Tous les dossiers liés à ce compte seront supprimés d'ExcalidrawZ."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ को %@ से अलग करें? इस खाते के लिए सभी लिंक किए गए फ़ोल्डर्स ExcalidrawZ से हटा दिए जाएंगे।"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnettere %@ da %@? Tutte le cartelle collegate a questo account verranno rimosse da ExcalidrawZ."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@を%@から切断しますか？このアカウントのすべてのリンクされたフォルダーがExcalidrawZから削除されます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@을(를) %@에서 연결 해제하시겠습니까? 이 계정에 대한 모든 연결 폴더가 ExcalidrawZ에서 제거됩니다."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ontkoppel %@ van %@? Alle gekoppelde mappen voor dit account worden verwijderd uit ExcalidrawZ."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Czy odłączyć %@ od %@? Wszystkie powiązane foldery dla tego konta zostaną usunięte z ExcalidrawZ."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconectar %@ de %@? Todas as pastas vinculadas a esta conta serão removidas do ExcalidrawZ."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отключить %@ от %@? Все связанные папки для этой учетной записи будут удалены из ExcalidrawZ."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัดการเชื่อมต่อ %@ จาก %@? โฟลเดอร์ที่เชื่อมโยงทั้งหมดสำหรับบัญชีนี้จะถูกลบออกจาก ExcalidrawZ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@'yı %@'dan ayırmak istiyor musunuz? Bu hesap için tüm bağlı klasörler ExcalidrawZ'den kaldırılacaktır."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ngắt kết nối %@ khỏi %@? Tất cả các thư mục liên kết cho tài khoản này sẽ bị xóa khỏi ExcalidrawZ."
+          }
+        }
+      }
+    },
+    "settingsCloudStorageDisconnectTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnect Account?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "断开帐户？"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "斷開帳戶連接？"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هل تريد قطع الاتصال بالحساب؟"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konto trennen?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Desconectar Cuenta?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déconnecter le compte ?"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "खाता अलग करें?"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnetti Account?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アカウントを切断しますか？"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "계정 연결 해제?"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Account ontkoppelen?"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Czy odłączyć konto?"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconectar Conta?"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отключить учетную запись?"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัดการเชื่อมต่อบัญชี?"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hesabı Bağlantısını Kesmek Mi?"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ngắt kết nối tài khoản?"
+          }
+        }
+      }
+    },
+    "settingsCloudStorageNoConnectedAccounts": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Connected Accounts"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有连接的帐户"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有已連接的帳戶"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد حسابات متصلة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine verbundenen Konten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay Cuentas Conectadas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun compte connecté"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कोई जुड़े हुए खाते नहीं"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun Account Connesso"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続されたアカウントはありません"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연결된 계정이 없습니다."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geen verbonden accounts"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brak połączonych kont"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhuma Conta Conectada"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет подключенных учетных записей"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่มีบัญชีที่เชื่อมต่อ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bağlı Hesap Yok"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không có tài khoản nào được kết nối"
+          }
+        }
+      }
+    },
+    "settingsCloudStorageNoConnectedAccountsDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect a cloud storage provider from Linked Storage in the sidebar."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从侧边栏的链接存储中连接一个云存储提供商。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "從側邊欄的鏈接存儲中連接一個雲存儲提供商。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قم بتوصيل مزود تخزين سحابي من التخزين المرتبط في شريط الجانب."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbinden Sie einen Cloud-Speicheranbieter über den verlinkten Speicher in der Seitenleiste."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conecta un proveedor de almacenamiento en la nube desde Almacenamiento Vinculado en la barra lateral."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connectez un fournisseur de stockage cloud dans le stockage lié dans la barre latérale."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "साइडबार में लिंक किए गए स्टोरेज से एक क्लाउड स्टोरेज प्रदाता कनेक्ट करें।"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collega un fornitore di cloud storage da Storage Collegato nella barra laterale."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サイドバーのリンクストレージからクラウドストレージプロバイダーを接続してください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사이드바의 연결된 저장소에서 클라우드 저장소 제공업체를 연결하십시오."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbind een cloudopslagprovider via Verbonden Opslag in de zijbalk."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Podłącz dostawcę pamięci w chmurze z powiązanej pamięci w pasku bocznym."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conecte um provedor de armazenamento em nuvem a partir do Armazenamento Vinculado na barra lateral."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подключите облачного хранилища в разделе Связанные хранилища в боковом меню."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เชื่อมต่อผู้ให้บริการพื้นที่จัดเก็บคลาวด์จากพื้นที่จัดเก็บที่เชื่อมโยงในแถบด้านข้าง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yan paneldeki Bağlı Depolama'dan bir bulut depolama sağlayıcısını bağlayın."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kết nối một nhà cung cấp lưu trữ đám mây từ Lưu trữ liên kết trong thanh bên."
+          }
+        }
+      }
+    },
     "settingsExcalidraw": {
       "extractionState": "manual",
       "localizations": {
@@ -137996,185 +138674,905 @@
     "whatsNewCloudStorageDescription": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "اربط OneDrive وDropbox وخدمات WebDAV لتصفح ملفات Excalidraw وتحريرها والحفاظ على مزامنتها." } },
-        "de": { "stringUnit": { "state": "translated", "value": "Verbinde OneDrive, Dropbox und WebDAV-Dienste, um Excalidraw-Dateien zu durchsuchen, zu bearbeiten und zu synchronisieren." } },
-        "en": { "stringUnit": { "state": "translated", "value": "Connect OneDrive, Dropbox, and WebDAV services to browse, edit, and keep your Excalidraw files in sync." } },
-        "es": { "stringUnit": { "state": "translated", "value": "Conecta OneDrive, Dropbox y servicios WebDAV para explorar, editar y mantener sincronizados tus archivos de Excalidraw." } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Connectez OneDrive, Dropbox et des services WebDAV pour parcourir, modifier et synchroniser vos fichiers Excalidraw." } },
-        "hi": { "stringUnit": { "state": "translated", "value": "Excalidraw फ़ाइलें ब्राउज़, संपादित और सिंक रखने के लिए OneDrive, Dropbox और WebDAV सेवाएँ कनेक्ट करें।" } },
-        "it": { "stringUnit": { "state": "translated", "value": "Connetti OneDrive, Dropbox e servizi WebDAV per sfogliare, modificare e sincronizzare i file Excalidraw." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "OneDrive、Dropbox、WebDAVサービスに接続し、Excalidrawファイルを参照、編集、同期できます。" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "OneDrive, Dropbox 및 WebDAV 서비스를 연결하여 Excalidraw 파일을 탐색, 편집 및 동기화하세요." } },
-        "nl": { "stringUnit": { "state": "translated", "value": "Verbind OneDrive, Dropbox en WebDAV-diensten om Excalidraw-bestanden te bekijken, bewerken en synchroniseren." } },
-        "pl": { "stringUnit": { "state": "translated", "value": "Połącz OneDrive, Dropbox i usługi WebDAV, aby przeglądać, edytować i synchronizować pliki Excalidraw." } },
-        "pt": { "stringUnit": { "state": "translated", "value": "Conecte OneDrive, Dropbox e serviços WebDAV para navegar, editar e manter seus arquivos do Excalidraw sincronizados." } },
-        "ru": { "stringUnit": { "state": "translated", "value": "Подключайте OneDrive, Dropbox и сервисы WebDAV, чтобы просматривать, редактировать и синхронизировать файлы Excalidraw." } },
-        "th": { "stringUnit": { "state": "translated", "value": "เชื่อมต่อ OneDrive, Dropbox และบริการ WebDAV เพื่อเรียกดู แก้ไข และซิงค์ไฟล์ Excalidraw ของคุณ" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "Excalidraw dosyalarınıza göz atmak, düzenlemek ve eşitlemek için OneDrive, Dropbox ve WebDAV hizmetlerini bağlayın." } },
-        "vi": { "stringUnit": { "state": "translated", "value": "Kết nối OneDrive, Dropbox và các dịch vụ WebDAV để duyệt, chỉnh sửa và đồng bộ tệp Excalidraw." } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "连接 OneDrive、Dropbox 和 WebDAV 服务，浏览、编辑并同步你的 Excalidraw 文件。" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "連接 OneDrive、Dropbox 和 WebDAV 服務，瀏覽、編輯並同步你的 Excalidraw 檔案。" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اربط OneDrive وDropbox وخدمات WebDAV لتصفح ملفات Excalidraw وتحريرها والحفاظ على مزامنتها."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbinde OneDrive, Dropbox und WebDAV-Dienste, um Excalidraw-Dateien zu durchsuchen, zu bearbeiten und zu synchronisieren."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect OneDrive, Dropbox, and WebDAV services to browse, edit, and keep your Excalidraw files in sync."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conecta OneDrive, Dropbox y servicios WebDAV para explorar, editar y mantener sincronizados tus archivos de Excalidraw."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connectez OneDrive, Dropbox et des services WebDAV pour parcourir, modifier et synchroniser vos fichiers Excalidraw."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excalidraw फ़ाइलें ब्राउज़, संपादित और सिंक रखने के लिए OneDrive, Dropbox और WebDAV सेवाएँ कनेक्ट करें।"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connetti OneDrive, Dropbox e servizi WebDAV per sfogliare, modificare e sincronizzare i file Excalidraw."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OneDrive、Dropbox、WebDAVサービスに接続し、Excalidrawファイルを参照、編集、同期できます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OneDrive, Dropbox 및 WebDAV 서비스를 연결하여 Excalidraw 파일을 탐색, 편집 및 동기화하세요."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbind OneDrive, Dropbox en WebDAV-diensten om Excalidraw-bestanden te bekijken, bewerken en synchroniseren."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Połącz OneDrive, Dropbox i usługi WebDAV, aby przeglądać, edytować i synchronizować pliki Excalidraw."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conecte OneDrive, Dropbox e serviços WebDAV para navegar, editar e manter seus arquivos do Excalidraw sincronizados."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подключайте OneDrive, Dropbox и сервисы WebDAV, чтобы просматривать, редактировать и синхронизировать файлы Excalidraw."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เชื่อมต่อ OneDrive, Dropbox และบริการ WebDAV เพื่อเรียกดู แก้ไข และซิงค์ไฟล์ Excalidraw ของคุณ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excalidraw dosyalarınıza göz atmak, düzenlemek ve eşitlemek için OneDrive, Dropbox ve WebDAV hizmetlerini bağlayın."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kết nối OneDrive, Dropbox và các dịch vụ WebDAV để duyệt, chỉnh sửa và đồng bộ tệp Excalidraw."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接 OneDrive、Dropbox 和 WebDAV 服务，浏览、编辑并同步你的 Excalidraw 文件。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "連接 OneDrive、Dropbox 和 WebDAV 服務，瀏覽、編輯並同步你的 Excalidraw 檔案。"
+          }
+        }
       }
     },
     "whatsNewCloudStorageTitle": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "التخزين السحابي" } },
-        "de": { "stringUnit": { "state": "translated", "value": "Cloud-Speicher" } },
-        "en": { "stringUnit": { "state": "translated", "value": "Cloud Storage" } },
-        "es": { "stringUnit": { "state": "translated", "value": "Almacenamiento en la nube" } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Stockage cloud" } },
-        "hi": { "stringUnit": { "state": "translated", "value": "क्लाउड स्टोरेज" } },
-        "it": { "stringUnit": { "state": "translated", "value": "Archiviazione cloud" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "クラウドストレージ" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "클라우드 저장소" } },
-        "nl": { "stringUnit": { "state": "translated", "value": "Cloudopslag" } },
-        "pl": { "stringUnit": { "state": "translated", "value": "Pamięć w chmurze" } },
-        "pt": { "stringUnit": { "state": "translated", "value": "Armazenamento em nuvem" } },
-        "ru": { "stringUnit": { "state": "translated", "value": "Облачное хранилище" } },
-        "th": { "stringUnit": { "state": "translated", "value": "พื้นที่จัดเก็บบนคลาวด์" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "Bulut Depolama" } },
-        "vi": { "stringUnit": { "state": "translated", "value": "Lưu trữ đám mây" } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "云存储" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "雲端儲存空間" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التخزين السحابي"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud-Speicher"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud Storage"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Almacenamiento en la nube"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stockage cloud"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "क्लाउड स्टोरेज"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Archiviazione cloud"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラウドストレージ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "클라우드 저장소"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudopslag"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pamięć w chmurze"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Armazenamento em nuvem"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Облачное хранилище"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "พื้นที่จัดเก็บบนคลาวด์"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bulut Depolama"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lưu trữ đám mây"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "云存储"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "雲端儲存空間"
+          }
+        }
       }
     },
     "whatsNewDropboxDescription": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "اربط مجلدات Dropbox وتصفح رسوماتك وحررها ونظمها من ExcalidrawZ." } },
-        "de": { "stringUnit": { "state": "translated", "value": "Verknüpfe Dropbox-Ordner und durchsuche, bearbeite und organisiere deine Zeichnungen in ExcalidrawZ." } },
-        "en": { "stringUnit": { "state": "translated", "value": "Link Dropbox folders and browse, edit, and organize your drawings from ExcalidrawZ." } },
-        "es": { "stringUnit": { "state": "translated", "value": "Vincula carpetas de Dropbox y explora, edita y organiza tus dibujos desde ExcalidrawZ." } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Liez des dossiers Dropbox et parcourez, modifiez et organisez vos dessins depuis ExcalidrawZ." } },
-        "hi": { "stringUnit": { "state": "translated", "value": "Dropbox फ़ोल्डर लिंक करें और ExcalidrawZ से अपने ड्रॉइंग ब्राउज़, संपादित और व्यवस्थित करें।" } },
-        "it": { "stringUnit": { "state": "translated", "value": "Collega le cartelle Dropbox e sfoglia, modifica e organizza i disegni da ExcalidrawZ." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "Dropboxフォルダをリンクし、ExcalidrawZから描画を参照、編集、整理できます。" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "Dropbox 폴더를 연결하고 ExcalidrawZ에서 드로잉을 탐색, 편집 및 정리하세요." } },
-        "nl": { "stringUnit": { "state": "translated", "value": "Koppel Dropbox-mappen en blader, bewerk en orden je tekeningen vanuit ExcalidrawZ." } },
-        "pl": { "stringUnit": { "state": "translated", "value": "Połącz foldery Dropbox oraz przeglądaj, edytuj i organizuj rysunki w ExcalidrawZ." } },
-        "pt": { "stringUnit": { "state": "translated", "value": "Vincule pastas do Dropbox e navegue, edite e organize seus desenhos pelo ExcalidrawZ." } },
-        "ru": { "stringUnit": { "state": "translated", "value": "Подключайте папки Dropbox и просматривайте, редактируйте и упорядочивайте рисунки в ExcalidrawZ." } },
-        "th": { "stringUnit": { "state": "translated", "value": "เชื่อมโยงโฟลเดอร์ Dropbox แล้วเรียกดู แก้ไข และจัดระเบียบภาพวาดจาก ExcalidrawZ" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "Dropbox klasörlerini bağlayın; çizimlerinize ExcalidrawZ üzerinden göz atın, düzenleyin ve organize edin." } },
-        "vi": { "stringUnit": { "state": "translated", "value": "Liên kết thư mục Dropbox và duyệt, chỉnh sửa, sắp xếp bản vẽ từ ExcalidrawZ." } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "关联 Dropbox 文件夹，直接在 ExcalidrawZ 中浏览、编辑和整理绘图。" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "連結 Dropbox 資料夾，直接在 ExcalidrawZ 中瀏覽、編輯與整理繪圖。" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اربط مجلدات Dropbox وتصفح رسوماتك وحررها ونظمها من ExcalidrawZ."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verknüpfe Dropbox-Ordner und durchsuche, bearbeite und organisiere deine Zeichnungen in ExcalidrawZ."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Link Dropbox folders and browse, edit, and organize your drawings from ExcalidrawZ."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vincula carpetas de Dropbox y explora, edita y organiza tus dibujos desde ExcalidrawZ."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liez des dossiers Dropbox et parcourez, modifiez et organisez vos dessins depuis ExcalidrawZ."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dropbox फ़ोल्डर लिंक करें और ExcalidrawZ से अपने ड्रॉइंग ब्राउज़, संपादित और व्यवस्थित करें।"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collega le cartelle Dropbox e sfoglia, modifica e organizza i disegni da ExcalidrawZ."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dropboxフォルダをリンクし、ExcalidrawZから描画を参照、編集、整理できます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dropbox 폴더를 연결하고 ExcalidrawZ에서 드로잉을 탐색, 편집 및 정리하세요."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koppel Dropbox-mappen en blader, bewerk en orden je tekeningen vanuit ExcalidrawZ."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Połącz foldery Dropbox oraz przeglądaj, edytuj i organizuj rysunki w ExcalidrawZ."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vincule pastas do Dropbox e navegue, edite e organize seus desenhos pelo ExcalidrawZ."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подключайте папки Dropbox и просматривайте, редактируйте и упорядочивайте рисунки в ExcalidrawZ."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เชื่อมโยงโฟลเดอร์ Dropbox แล้วเรียกดู แก้ไข และจัดระเบียบภาพวาดจาก ExcalidrawZ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dropbox klasörlerini bağlayın; çizimlerinize ExcalidrawZ üzerinden göz atın, düzenleyin ve organize edin."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liên kết thư mục Dropbox và duyệt, chỉnh sửa, sắp xếp bản vẽ từ ExcalidrawZ."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关联 Dropbox 文件夹，直接在 ExcalidrawZ 中浏览、编辑和整理绘图。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "連結 Dropbox 資料夾，直接在 ExcalidrawZ 中瀏覽、編輯與整理繪圖。"
+          }
+        }
       }
     },
     "whatsNewGoogleDriveDescription": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "اربط مجلدات Google Drive لإدارة ملفات Excalidraw عبر أجهزتك." } },
-        "de": { "stringUnit": { "state": "translated", "value": "Verknüpfe Google Drive-Ordner, um Excalidraw-Dateien auf deinen Geräten zu verwalten." } },
-        "en": { "stringUnit": { "state": "translated", "value": "Link Google Drive folders to manage Excalidraw files across your devices." } },
-        "es": { "stringUnit": { "state": "translated", "value": "Vincula carpetas de Google Drive para administrar archivos de Excalidraw en todos tus dispositivos." } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Liez des dossiers Google Drive pour gérer vos fichiers Excalidraw sur tous vos appareils." } },
-        "hi": { "stringUnit": { "state": "translated", "value": "अपने डिवाइसों पर Excalidraw फ़ाइलें प्रबंधित करने के लिए Google Drive फ़ोल्डर लिंक करें।" } },
-        "it": { "stringUnit": { "state": "translated", "value": "Collega le cartelle Google Drive per gestire i file Excalidraw su tutti i tuoi dispositivi." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "Google Driveフォルダをリンクして、複数のデバイスでExcalidrawファイルを管理できます。" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "Google Drive 폴더를 연결하여 여러 기기에서 Excalidraw 파일을 관리하세요." } },
-        "nl": { "stringUnit": { "state": "translated", "value": "Koppel Google Drive-mappen om Excalidraw-bestanden op al je apparaten te beheren." } },
-        "pl": { "stringUnit": { "state": "translated", "value": "Połącz foldery Google Drive, aby zarządzać plikami Excalidraw na wszystkich urządzeniach." } },
-        "pt": { "stringUnit": { "state": "translated", "value": "Vincule pastas do Google Drive para gerenciar arquivos do Excalidraw em seus dispositivos." } },
-        "ru": { "stringUnit": { "state": "translated", "value": "Подключайте папки Google Drive для управления файлами Excalidraw на разных устройствах." } },
-        "th": { "stringUnit": { "state": "translated", "value": "เชื่อมโยงโฟลเดอร์ Google Drive เพื่อจัดการไฟล์ Excalidraw บนอุปกรณ์ต่างๆ" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "Excalidraw dosyalarını cihazlarınızda yönetmek için Google Drive klasörlerini bağlayın." } },
-        "vi": { "stringUnit": { "state": "translated", "value": "Liên kết thư mục Google Drive để quản lý tệp Excalidraw trên các thiết bị." } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "关联 Google Drive 文件夹，在不同设备间管理 Excalidraw 文件。" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "連結 Google Drive 資料夾，在不同裝置間管理 Excalidraw 檔案。" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اربط مجلدات Google Drive لإدارة ملفات Excalidraw عبر أجهزتك."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verknüpfe Google Drive-Ordner, um Excalidraw-Dateien auf deinen Geräten zu verwalten."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Link Google Drive folders to manage Excalidraw files across your devices."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vincula carpetas de Google Drive para administrar archivos de Excalidraw en todos tus dispositivos."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liez des dossiers Google Drive pour gérer vos fichiers Excalidraw sur tous vos appareils."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अपने डिवाइसों पर Excalidraw फ़ाइलें प्रबंधित करने के लिए Google Drive फ़ोल्डर लिंक करें।"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collega le cartelle Google Drive per gestire i file Excalidraw su tutti i tuoi dispositivi."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Google Driveフォルダをリンクして、複数のデバイスでExcalidrawファイルを管理できます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Google Drive 폴더를 연결하여 여러 기기에서 Excalidraw 파일을 관리하세요."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koppel Google Drive-mappen om Excalidraw-bestanden op al je apparaten te beheren."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Połącz foldery Google Drive, aby zarządzać plikami Excalidraw na wszystkich urządzeniach."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vincule pastas do Google Drive para gerenciar arquivos do Excalidraw em seus dispositivos."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подключайте папки Google Drive для управления файлами Excalidraw на разных устройствах."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เชื่อมโยงโฟลเดอร์ Google Drive เพื่อจัดการไฟล์ Excalidraw บนอุปกรณ์ต่างๆ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excalidraw dosyalarını cihazlarınızda yönetmek için Google Drive klasörlerini bağlayın."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liên kết thư mục Google Drive để quản lý tệp Excalidraw trên các thiết bị."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关联 Google Drive 文件夹，在不同设备间管理 Excalidraw 文件。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "連結 Google Drive 資料夾，在不同裝置間管理 Excalidraw 檔案。"
+          }
+        }
       }
     },
     "whatsNewNativeColorPickerDescription": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "اختر الألوان من أي مكان على الشاشة باستخدام أداة القطّارة الأصلية على Mac وiPad وiPhone." } },
-        "de": { "stringUnit": { "state": "translated", "value": "Wähle Farben mit der systemeigenen Pipette direkt vom Bildschirm auf Mac, iPad und iPhone aus." } },
-        "en": { "stringUnit": { "state": "translated", "value": "Pick colors from anywhere on screen with the native eyedropper on Mac, iPad, and iPhone." } },
-        "es": { "stringUnit": { "state": "translated", "value": "Elige colores de cualquier parte de la pantalla con el cuentagotas nativo en Mac, iPad y iPhone." } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Prélevez des couleurs n'importe où à l'écran avec la pipette native sur Mac, iPad et iPhone." } },
-        "hi": { "stringUnit": { "state": "translated", "value": "Mac, iPad और iPhone पर नेटिव आईड्रॉपर से स्क्रीन पर कहीं से भी रंग चुनें।" } },
-        "it": { "stringUnit": { "state": "translated", "value": "Scegli i colori da qualsiasi punto dello schermo con il contagocce nativo su Mac, iPad e iPhone." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "Mac、iPad、iPhoneのネイティブスポイトで、画面上のどこからでも色を選択できます。" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "Mac, iPad 및 iPhone의 기본 스포이트로 화면 어디에서나 색상을 선택하세요." } },
-        "nl": { "stringUnit": { "state": "translated", "value": "Kies kleuren overal op het scherm met de systeemeigen pipet op Mac, iPad en iPhone." } },
-        "pl": { "stringUnit": { "state": "translated", "value": "Pobieraj kolory z dowolnego miejsca na ekranie za pomocą systemowej pipety na Macu, iPadzie i iPhonie." } },
-        "pt": { "stringUnit": { "state": "translated", "value": "Escolha cores em qualquer lugar da tela com o conta-gotas nativo no Mac, iPad e iPhone." } },
-        "ru": { "stringUnit": { "state": "translated", "value": "Выбирайте цвета в любой точке экрана с помощью системной пипетки на Mac, iPad и iPhone." } },
-        "th": { "stringUnit": { "state": "translated", "value": "เลือกสีจากที่ใดก็ได้บนหน้าจอด้วยเครื่องมือดูดสีของระบบบน Mac, iPad และ iPhone" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "Mac, iPad ve iPhone'daki yerel damlalıkla ekranın herhangi bir yerinden renk seçin." } },
-        "vi": { "stringUnit": { "state": "translated", "value": "Chọn màu ở bất kỳ đâu trên màn hình bằng công cụ hút màu hệ thống trên Mac, iPad và iPhone." } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "使用系统原生吸管，直接从 Mac、iPad 和 iPhone 屏幕的任意位置选取颜色。" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "使用系統原生滴管，直接從 Mac、iPad 和 iPhone 螢幕的任意位置選取顏色。" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اختر الألوان من أي مكان على الشاشة باستخدام أداة القطّارة الأصلية على Mac وiPad وiPhone."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wähle Farben mit der systemeigenen Pipette direkt vom Bildschirm auf Mac, iPad und iPhone aus."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pick colors from anywhere on screen with the native eyedropper on Mac, iPad, and iPhone."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige colores de cualquier parte de la pantalla con el cuentagotas nativo en Mac, iPad y iPhone."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prélevez des couleurs n'importe où à l'écran avec la pipette native sur Mac, iPad et iPhone."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac, iPad और iPhone पर नेटिव आईड्रॉपर से स्क्रीन पर कहीं से भी रंग चुनें।"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scegli i colori da qualsiasi punto dello schermo con il contagocce nativo su Mac, iPad e iPhone."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac、iPad、iPhoneのネイティブスポイトで、画面上のどこからでも色を選択できます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac, iPad 및 iPhone의 기본 스포이트로 화면 어디에서나 색상을 선택하세요."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kies kleuren overal op het scherm met de systeemeigen pipet op Mac, iPad en iPhone."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pobieraj kolory z dowolnego miejsca na ekranie za pomocą systemowej pipety na Macu, iPadzie i iPhonie."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escolha cores em qualquer lugar da tela com o conta-gotas nativo no Mac, iPad e iPhone."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выбирайте цвета в любой точке экрана с помощью системной пипетки на Mac, iPad и iPhone."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เลือกสีจากที่ใดก็ได้บนหน้าจอด้วยเครื่องมือดูดสีของระบบบน Mac, iPad และ iPhone"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac, iPad ve iPhone'daki yerel damlalıkla ekranın herhangi bir yerinden renk seçin."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chọn màu ở bất kỳ đâu trên màn hình bằng công cụ hút màu hệ thống trên Mac, iPad và iPhone."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用系统原生吸管，直接从 Mac、iPad 和 iPhone 屏幕的任意位置选取颜色。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用系統原生滴管，直接從 Mac、iPad 和 iPhone 螢幕的任意位置選取顏色。"
+          }
+        }
       }
     },
     "whatsNewNativeColorPickerTitle": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "منتقي الألوان الأصلي" } },
-        "de": { "stringUnit": { "state": "translated", "value": "System-Farbwähler" } },
-        "en": { "stringUnit": { "state": "translated", "value": "Native Color Picker" } },
-        "es": { "stringUnit": { "state": "translated", "value": "Selector de color nativo" } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Sélecteur de couleurs natif" } },
-        "hi": { "stringUnit": { "state": "translated", "value": "नेटिव रंग चयनकर्ता" } },
-        "it": { "stringUnit": { "state": "translated", "value": "Selettore colore nativo" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "ネイティブカラーピッカー" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "기본 색상 선택기" } },
-        "nl": { "stringUnit": { "state": "translated", "value": "Systeemkleurkiezer" } },
-        "pl": { "stringUnit": { "state": "translated", "value": "Systemowy próbnik kolorów" } },
-        "pt": { "stringUnit": { "state": "translated", "value": "Seletor de cores nativo" } },
-        "ru": { "stringUnit": { "state": "translated", "value": "Системная пипетка" } },
-        "th": { "stringUnit": { "state": "translated", "value": "ตัวเลือกสีของระบบ" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "Yerel Renk Seçici" } },
-        "vi": { "stringUnit": { "state": "translated", "value": "Bộ chọn màu hệ thống" } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "原生取色器" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "原生取色器" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "منتقي الألوان الأصلي"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System-Farbwähler"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Native Color Picker"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selector de color nativo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélecteur de couleurs natif"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नेटिव रंग चयनकर्ता"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selettore colore nativo"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネイティブカラーピッカー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본 색상 선택기"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systeemkleurkiezer"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systemowy próbnik kolorów"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seletor de cores nativo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Системная пипетка"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัวเลือกสีของระบบ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yerel Renk Seçici"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bộ chọn màu hệ thống"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "原生取色器"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "原生取色器"
+          }
+        }
       }
     },
     "whatsNewOneDriveDescription": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "اربط مجلدات OneDrive وافتح ملفات Excalidraw وعدّلها واحتفظ بمزامنتها." } },
-        "de": { "stringUnit": { "state": "translated", "value": "Verknüpfe OneDrive-Ordner und öffne, bearbeite und synchronisiere deine Excalidraw-Dateien." } },
-        "en": { "stringUnit": { "state": "translated", "value": "Link OneDrive folders and open, edit, and keep your Excalidraw files in sync." } },
-        "es": { "stringUnit": { "state": "translated", "value": "Vincula carpetas de OneDrive y abre, edita y mantén sincronizados tus archivos de Excalidraw." } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Liez des dossiers OneDrive et ouvrez, modifiez et synchronisez vos fichiers Excalidraw." } },
-        "hi": { "stringUnit": { "state": "translated", "value": "OneDrive फ़ोल्डर लिंक करें और अपनी Excalidraw फ़ाइलें खोलें, संपादित करें और सिंक रखें।" } },
-        "it": { "stringUnit": { "state": "translated", "value": "Collega le cartelle OneDrive e apri, modifica e mantieni sincronizzati i file Excalidraw." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "OneDriveフォルダをリンクし、Excalidrawファイルを開いて編集し、同期を保てます。" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "OneDrive 폴더를 연결하고 Excalidraw 파일을 열고 편집하며 동기화하세요." } },
-        "nl": { "stringUnit": { "state": "translated", "value": "Koppel OneDrive-mappen en open, bewerk en synchroniseer je Excalidraw-bestanden." } },
-        "pl": { "stringUnit": { "state": "translated", "value": "Połącz foldery OneDrive oraz otwieraj, edytuj i synchronizuj pliki Excalidraw." } },
-        "pt": { "stringUnit": { "state": "translated", "value": "Vincule pastas do OneDrive e abra, edite e mantenha seus arquivos do Excalidraw sincronizados." } },
-        "ru": { "stringUnit": { "state": "translated", "value": "Подключайте папки OneDrive, открывайте и редактируйте файлы Excalidraw и поддерживайте их синхронизацию." } },
-        "th": { "stringUnit": { "state": "translated", "value": "เชื่อมโยงโฟลเดอร์ OneDrive แล้วเปิด แก้ไข และซิงค์ไฟล์ Excalidraw ของคุณ" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "OneDrive klasörlerini bağlayın; Excalidraw dosyalarınızı açın, düzenleyin ve eşitlenmiş tutun." } },
-        "vi": { "stringUnit": { "state": "translated", "value": "Liên kết thư mục OneDrive để mở, chỉnh sửa và đồng bộ các tệp Excalidraw." } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "关联 OneDrive 文件夹，打开、编辑并同步你的 Excalidraw 文件。" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "連結 OneDrive 資料夾，開啟、編輯並同步你的 Excalidraw 檔案。" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اربط مجلدات OneDrive وافتح ملفات Excalidraw وعدّلها واحتفظ بمزامنتها."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verknüpfe OneDrive-Ordner und öffne, bearbeite und synchronisiere deine Excalidraw-Dateien."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Link OneDrive folders and open, edit, and keep your Excalidraw files in sync."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vincula carpetas de OneDrive y abre, edita y mantén sincronizados tus archivos de Excalidraw."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liez des dossiers OneDrive et ouvrez, modifiez et synchronisez vos fichiers Excalidraw."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OneDrive फ़ोल्डर लिंक करें और अपनी Excalidraw फ़ाइलें खोलें, संपादित करें और सिंक रखें।"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collega le cartelle OneDrive e apri, modifica e mantieni sincronizzati i file Excalidraw."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OneDriveフォルダをリンクし、Excalidrawファイルを開いて編集し、同期を保てます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OneDrive 폴더를 연결하고 Excalidraw 파일을 열고 편집하며 동기화하세요."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koppel OneDrive-mappen en open, bewerk en synchroniseer je Excalidraw-bestanden."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Połącz foldery OneDrive oraz otwieraj, edytuj i synchronizuj pliki Excalidraw."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vincule pastas do OneDrive e abra, edite e mantenha seus arquivos do Excalidraw sincronizados."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подключайте папки OneDrive, открывайте и редактируйте файлы Excalidraw и поддерживайте их синхронизацию."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เชื่อมโยงโฟลเดอร์ OneDrive แล้วเปิด แก้ไข และซิงค์ไฟล์ Excalidraw ของคุณ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OneDrive klasörlerini bağlayın; Excalidraw dosyalarınızı açın, düzenleyin ve eşitlenmiş tutun."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liên kết thư mục OneDrive để mở, chỉnh sửa và đồng bộ các tệp Excalidraw."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关联 OneDrive 文件夹，打开、编辑并同步你的 Excalidraw 文件。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "連結 OneDrive 資料夾，開啟、編輯並同步你的 Excalidraw 檔案。"
+          }
+        }
       }
     },
     "whatsNewWebDAVDescription": {
       "extractionState": "manual",
       "localizations": {
-        "ar": { "stringUnit": { "state": "translated", "value": "اربط خدمات WebDAV المتوافقة، بما فيها Nextcloud وownCloud وNutstore وغيرها." } },
-        "de": { "stringUnit": { "state": "translated", "value": "Verbinde kompatible WebDAV-Dienste, darunter Nextcloud, ownCloud, Nutstore und weitere." } },
-        "en": { "stringUnit": { "state": "translated", "value": "Connect compatible WebDAV services, including Nextcloud, ownCloud, Nutstore, and more." } },
-        "es": { "stringUnit": { "state": "translated", "value": "Conecta servicios WebDAV compatibles, incluidos Nextcloud, ownCloud, Nutstore y otros." } },
-        "fr": { "stringUnit": { "state": "translated", "value": "Connectez des services WebDAV compatibles, notamment Nextcloud, ownCloud, Nutstore et plus encore." } },
-        "hi": { "stringUnit": { "state": "translated", "value": "Nextcloud, ownCloud, Nutstore और अन्य संगत WebDAV सेवाएँ कनेक्ट करें।" } },
-        "it": { "stringUnit": { "state": "translated", "value": "Connetti servizi WebDAV compatibili, tra cui Nextcloud, ownCloud, Nutstore e altri." } },
-        "ja": { "stringUnit": { "state": "translated", "value": "Nextcloud、ownCloud、Nutstoreなど、互換性のあるWebDAVサービスに接続できます。" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "Nextcloud, ownCloud, Nutstore 등 호환되는 WebDAV 서비스에 연결하세요." } },
-        "nl": { "stringUnit": { "state": "translated", "value": "Verbind compatibele WebDAV-diensten, waaronder Nextcloud, ownCloud, Nutstore en meer." } },
-        "pl": { "stringUnit": { "state": "translated", "value": "Połącz zgodne usługi WebDAV, w tym Nextcloud, ownCloud, Nutstore i inne." } },
-        "pt": { "stringUnit": { "state": "translated", "value": "Conecte serviços WebDAV compatíveis, incluindo Nextcloud, ownCloud, Nutstore e outros." } },
-        "ru": { "stringUnit": { "state": "translated", "value": "Подключайте совместимые сервисы WebDAV, включая Nextcloud, ownCloud, Nutstore и другие." } },
-        "th": { "stringUnit": { "state": "translated", "value": "เชื่อมต่อบริการ WebDAV ที่รองรับ รวมถึง Nextcloud, ownCloud, Nutstore และอื่นๆ" } },
-        "tr": { "stringUnit": { "state": "translated", "value": "Nextcloud, ownCloud, Nutstore ve daha fazlası dahil uyumlu WebDAV hizmetlerine bağlanın." } },
-        "vi": { "stringUnit": { "state": "translated", "value": "Kết nối các dịch vụ WebDAV tương thích, gồm Nextcloud, ownCloud, Nutstore và nhiều dịch vụ khác." } },
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "连接兼容的 WebDAV 服务，包括 Nextcloud、ownCloud、坚果云等。" } },
-        "zh-Hant": { "stringUnit": { "state": "translated", "value": "連接相容的 WebDAV 服務，包括 Nextcloud、ownCloud、Nutstore 等。" } }
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اربط خدمات WebDAV المتوافقة، بما فيها Nextcloud وownCloud وNutstore وغيرها."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbinde kompatible WebDAV-Dienste, darunter Nextcloud, ownCloud, Nutstore und weitere."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect compatible WebDAV services, including Nextcloud, ownCloud, Nutstore, and more."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conecta servicios WebDAV compatibles, incluidos Nextcloud, ownCloud, Nutstore y otros."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connectez des services WebDAV compatibles, notamment Nextcloud, ownCloud, Nutstore et plus encore."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nextcloud, ownCloud, Nutstore और अन्य संगत WebDAV सेवाएँ कनेक्ट करें।"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connetti servizi WebDAV compatibili, tra cui Nextcloud, ownCloud, Nutstore e altri."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nextcloud、ownCloud、Nutstoreなど、互換性のあるWebDAVサービスに接続できます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nextcloud, ownCloud, Nutstore 등 호환되는 WebDAV 서비스에 연결하세요."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbind compatibele WebDAV-diensten, waaronder Nextcloud, ownCloud, Nutstore en meer."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Połącz zgodne usługi WebDAV, w tym Nextcloud, ownCloud, Nutstore i inne."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conecte serviços WebDAV compatíveis, incluindo Nextcloud, ownCloud, Nutstore e outros."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подключайте совместимые сервисы WebDAV, включая Nextcloud, ownCloud, Nutstore и другие."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เชื่อมต่อบริการ WebDAV ที่รองรับ รวมถึง Nextcloud, ownCloud, Nutstore และอื่นๆ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nextcloud, ownCloud, Nutstore ve daha fazlası dahil uyumlu WebDAV hizmetlerine bağlanın."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kết nối các dịch vụ WebDAV tương thích, gồm Nextcloud, ownCloud, Nutstore và nhiều dịch vụ khác."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接兼容的 WebDAV 服务，包括 Nextcloud、ownCloud、坚果云等。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "連接相容的 WebDAV 服務，包括 Nextcloud、ownCloud、Nutstore 等。"
+          }
+        }
       }
     },
     "whatsNewCanvasPreferencesDescription": {

--- a/ExcalidrawZ/Persistence/CloudStorage/CloudStorageConnectionStore.swift
+++ b/ExcalidrawZ/Persistence/CloudStorage/CloudStorageConnectionStore.swift
@@ -251,7 +251,20 @@ final class CloudStorageConnectionStore: ObservableObject {
             "Starting interactive cloud storage authorization provider=\(location.providerID.rawValue) location=\(location.displayName) id=\(location.id) accountID=\(location.accountID)"
         )
 #endif
-        let account = try await connect(to: location.providerID)
+        let provider = try await registry.provider(withID: location.providerID)
+        let accountHint = account(for: location)
+        let account: CloudStorageAccount
+        if provider.requiresLocationSelectionForReauthorization {
+            connectingProviderIDs.insert(location.providerID)
+            defer { connectingProviderIDs.remove(location.providerID) }
+            account = try await provider.reauthorizeAccess(
+                to: location,
+                accountHint: accountHint
+            )
+            storeConnectedAccount(account)
+        } else {
+            account = try await connect(to: location.providerID)
+        }
         guard account.id == location.accountID else {
             accessFailureLocationIDs.insert(location.id)
             publishAuthenticationRequirements()

--- a/ExcalidrawZ/Persistence/CloudStorage/CloudStorageDocumentStore.swift
+++ b/ExcalidrawZ/Persistence/CloudStorage/CloudStorageDocumentStore.swift
@@ -198,6 +198,19 @@ final class CloudStorageDocumentStore: ObservableObject {
         return item(for: folder)?.effectiveCapabilities ?? .writableFolder
     }
 
+    func canCreateFolder(
+        in folder: CloudStorageFolderReference,
+        connections: CloudStorageConnectionStore? = nil
+    ) -> Bool {
+        guard capabilities(for: folder).contains(.createChildren) else {
+            return false
+        }
+        let connections = connections ?? .shared
+        return connections.providerDescriptors.first(where: {
+            $0.id == folder.location.providerID
+        })?.capabilities.contains(.createFolder) == true
+    }
+
     func remoteURL(
         for reference: CloudStorageDocumentReference,
         connections: CloudStorageConnectionStore? = nil
@@ -1580,11 +1593,9 @@ final class CloudStorageDocumentStore: ObservableObject {
     ) async throws -> CloudStorageFolderReference {
         let connections = connections ?? .shared
         ensureLocationStateLoaded(folder.location.id)
-        try Self.require(
-            .createChildren,
-            in: capabilities(for: folder),
-            operation: .createFolder
-        )
+        guard canCreateFolder(in: folder, connections: connections) else {
+            throw CloudStorageError.unsupportedOperation(.createFolder)
+        }
         let item = Self.pendingItem(
             name: name,
             kind: .folder,

--- a/ExcalidrawZ/Persistence/CloudStorage/CloudStorageDocumentStore.swift
+++ b/ExcalidrawZ/Persistence/CloudStorage/CloudStorageDocumentStore.swift
@@ -116,6 +116,9 @@ final class CloudStorageDocumentStore: ObservableObject {
     private var replayingMetadataOperationIDs: Set<UUID> = []
     private var remoteContentMutationGeneration: UInt64 = 0
     private var remoteContentMutationGenerationByItem: [MetadataMutationKey: UInt64] = [:]
+    private var itemIdentityAliasesByLocationID: [
+        UUID: [CloudStorageItemID: CloudStorageItemID]
+    ] = [:]
     private var resolvingConflictDocumentIDs: Set<String> = []
     private var activeLocalCacheMutationCounts: [String: Int] = [:]
 
@@ -256,14 +259,44 @@ final class CloudStorageDocumentStore: ObservableObject {
     func latestReference(
         for reference: CloudStorageDocumentReference
     ) -> CloudStorageDocumentReference? {
-        guard let item = item(for: reference) else { return nil }
+        let resolvedReference = resolvingCurrentIdentity(for: reference)
+        guard let item = item(for: resolvedReference) else { return nil }
+        return CloudStorageDocumentReference(
+            locationID: resolvedReference.locationID,
+            providerID: resolvedReference.providerID,
+            accountID: resolvedReference.accountID,
+            itemID: resolvedReference.itemID,
+            lastKnownName: item.name,
+            lastKnownModifiedAt: item.modifiedAt,
+            activeFileID: reference.activeFileID
+        )
+    }
+
+    /// Resolves a provisional local-first identity after its provider assigns
+    /// the remote item ID. The notification normally updates active sessions,
+    /// but a very fast create can complete before the new file is activated.
+    func resolvingCurrentIdentity(
+        for reference: CloudStorageDocumentReference
+    ) -> CloudStorageDocumentReference {
+        let aliases = itemIdentityAliasesByLocationID[reference.locationID] ?? [:]
+        var itemID = reference.itemID
+        var visited = Set<CloudStorageItemID>()
+        while visited.insert(itemID).inserted, let replacement = aliases[itemID] {
+            itemID = replacement
+        }
+
+        guard itemID != reference.itemID,
+              let item = itemsByLocationID[reference.locationID]?[itemID] else {
+            return reference
+        }
         return CloudStorageDocumentReference(
             locationID: reference.locationID,
             providerID: reference.providerID,
             accountID: reference.accountID,
-            itemID: reference.itemID,
+            itemID: item.id,
             lastKnownName: item.name,
-            lastKnownModifiedAt: item.modifiedAt
+            lastKnownModifiedAt: item.modifiedAt,
+            activeFileID: reference.activeFileID
         )
     }
 
@@ -1789,6 +1822,7 @@ final class CloudStorageDocumentStore: ObservableObject {
         errorsByLocationID.removeValue(forKey: locationID)
         automaticRetryDatesByLocationID.removeValue(forKey: locationID)
         processingFolderIDsByLocationID.removeValue(forKey: locationID)
+        itemIdentityAliasesByLocationID.removeValue(forKey: locationID)
         remoteContentMutationGenerationByItem = remoteContentMutationGenerationByItem.filter {
             $0.key.locationID != locationID
         }
@@ -2691,10 +2725,28 @@ final class CloudStorageDocumentStore: ObservableObject {
 
         apply(state, to: locationID)
         try persist(state, for: locationID)
+        recordIdentityAliases(replacements, locationID: locationID)
         recordRemoteContentMutation(locationID: locationID, itemID: updatedItem.id)
         return Dictionary(uniqueKeysWithValues: replacements.compactMap { oldID, newID in
             state.items.first(where: { $0.id == newID }).map { (oldID, $0) }
         })
+    }
+
+    private func recordIdentityAliases(
+        _ replacements: [CloudStorageItemID: CloudStorageItemID],
+        locationID: UUID
+    ) {
+        var aliases = itemIdentityAliasesByLocationID[locationID] ?? [:]
+        for (oldID, newID) in replacements where oldID != newID {
+            let chainedAliases = aliases.compactMap { alias, target in
+                target == oldID ? alias : nil
+            }
+            for alias in chainedAliases {
+                aliases[alias] = newID
+            }
+            aliases[oldID] = newID
+        }
+        itemIdentityAliasesByLocationID[locationID] = aliases
     }
 
     private static func replacingItemIdentity(

--- a/ExcalidrawZ/Persistence/CloudStorage/CloudStorageProvider.swift
+++ b/ExcalidrawZ/Persistence/CloudStorage/CloudStorageProvider.swift
@@ -20,6 +20,7 @@ extension URLRequest {
 
 protocol CloudStorageProvider: Sendable {
     var descriptor: CloudStorageProviderDescriptor { get }
+    var requiresLocationSelectionForReauthorization: Bool { get }
 
     func authorizationStatus() async -> CloudStorageAuthorizationStatus
     func authorize() async throws -> CloudStorageAccount
@@ -28,6 +29,10 @@ protocol CloudStorageProvider: Sendable {
     ) async throws -> CloudStorageAccount
     func makeSession(for account: CloudStorageAccount) async throws -> any CloudStorageSession
     func signOut(accountID: CloudStorageAccountID) async throws
+    func reauthorizeAccess(
+        to location: CloudStorageLocation,
+        accountHint: CloudStorageAccount?
+    ) async throws -> CloudStorageAccount
 
     /// Begins the provider's preferred root-selection flow. Most providers
     /// authenticate first and then use ExcalidrawZ's folder browser. Providers
@@ -48,6 +53,18 @@ enum CloudStorageLocationSelection: Sendable {
 }
 
 extension CloudStorageProvider {
+    var requiresLocationSelectionForReauthorization: Bool { false }
+
+    /// Reauthorizes a persisted location whose credential can no longer be
+    /// restored. Providers with resource-scoped authorization can override
+    /// this to ask the user to grant the original root again.
+    func reauthorizeAccess(
+        to location: CloudStorageLocation,
+        accountHint: CloudStorageAccount?
+    ) async throws -> CloudStorageAccount {
+        try await authorize()
+    }
+
     func authorize(
         using connectionInput: CloudStorageConnectionInput?
     ) async throws -> CloudStorageAccount {

--- a/ExcalidrawZ/Persistence/CloudStorage/GoogleDrive/GoogleDriveAPIClient.swift
+++ b/ExcalidrawZ/Persistence/CloudStorage/GoogleDrive/GoogleDriveAPIClient.swift
@@ -197,7 +197,9 @@ actor GoogleDriveAPIClient {
         named name: String,
         in parentID: CloudStorageItemID
     ) async throws {
-        let escapedName = name.replacingOccurrences(of: "'", with: "\\'")
+        let escapedName = name
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "'", with: "\\'")
         let response: GoogleDriveFileList = try await get(
             configuration.apiBaseURL.appending(path: "files"),
             queryItems: commonQueryItems + [

--- a/ExcalidrawZ/Persistence/CloudStorage/GoogleDrive/GoogleDriveAuthentication.swift
+++ b/ExcalidrawZ/Persistence/CloudStorage/GoogleDrive/GoogleDriveAuthentication.swift
@@ -12,8 +12,14 @@ protocol GoogleDriveAccessTokenProviding: Sendable {
 protocol GoogleDriveAuthenticating: GoogleDriveAccessTokenProviding {
     func accounts() async throws -> [CloudStorageAccount]
     func authorize() async throws -> CloudStorageAccount
-    func accountWithRequiredScope(
-        accountHint: CloudStorageAccount?
-    ) async throws -> CloudStorageAccount
+    func authorizeAndSelectFolder(
+        accountHint: CloudStorageAccount?,
+        folderIDHint: CloudStorageItemID?
+    ) async throws -> GoogleDriveFolderAuthorization
     func signOut(accountID: CloudStorageAccountID) async throws
+}
+
+struct GoogleDriveFolderAuthorization: Sendable {
+    let account: CloudStorageAccount
+    let folderID: CloudStorageItemID
 }

--- a/ExcalidrawZ/Persistence/CloudStorage/GoogleDrive/GoogleDriveCloudStorageProvider.swift
+++ b/ExcalidrawZ/Persistence/CloudStorage/GoogleDrive/GoogleDriveCloudStorageProvider.swift
@@ -7,15 +7,27 @@ import Foundation
 import Logging
 
 struct GoogleDriveCloudStorageProvider: CloudStorageProvider {
+    // `drive.file` only exposes items selected through Picker or created by
+    // ExcalidrawZ. Selecting a folder does not recursively grant its existing
+    // descendants, so this provider must not advertise full folder semantics.
+    private static let driveFileCapabilities: CloudStorageProviderCapabilities = [
+        .createFile,
+        .updateFile,
+        .moveItem,
+        .deleteItem,
+    ]
+
     let descriptor = CloudStorageProviderDescriptor(
         id: .googleDrive,
         displayName: "Google Drive",
-        capabilities: .readWrite
+        capabilities: driveFileCapabilities
     )
 
     private let authenticator: any GoogleDriveAuthenticating
     private let configuration: GoogleDriveConfiguration
     private let logger = Logger(label: "GoogleDriveCloudStorageProvider")
+
+    let requiresLocationSelectionForReauthorization = true
 
     init(
         authenticator: any GoogleDriveAuthenticating,
@@ -42,8 +54,34 @@ struct GoogleDriveCloudStorageProvider: CloudStorageProvider {
     func selectLocation(
         for account: CloudStorageAccount?
     ) async throws -> CloudStorageLocationSelection {
-        let account = try await authenticator.accountWithRequiredScope(accountHint: account)
-        return .browse(account: account)
+        let selection = try await authenticator.authorizeAndSelectFolder(
+            accountHint: account,
+            folderIDHint: nil
+        )
+        let session = try await makeSession(for: selection.account)
+        let folder = try await session.item(for: selection.folderID)
+        guard folder.kind == .folder else {
+            throw CloudStorageError.invalidProviderResponse(
+                "Google Picker did not return a folder."
+            )
+        }
+        return .selected(account: selection.account, folder: folder)
+    }
+
+    func reauthorizeAccess(
+        to location: CloudStorageLocation,
+        accountHint: CloudStorageAccount?
+    ) async throws -> CloudStorageAccount {
+        let selection = try await authenticator.authorizeAndSelectFolder(
+            accountHint: accountHint,
+            folderIDHint: location.rootItemID
+        )
+        guard selection.folderID == location.rootItemID else {
+            throw CloudStorageError.invalidProviderResponse(
+                "Select the Google Drive folder previously linked to ExcalidrawZ."
+            )
+        }
+        return selection.account
     }
 
     func makeSession(for account: CloudStorageAccount) async throws -> any CloudStorageSession {

--- a/ExcalidrawZ/Persistence/CloudStorage/GoogleDrive/GoogleDriveCloudStorageSession.swift
+++ b/ExcalidrawZ/Persistence/CloudStorage/GoogleDrive/GoogleDriveCloudStorageSession.swift
@@ -8,10 +8,14 @@ import Foundation
 actor GoogleDriveCloudStorageSession: CloudStorageSession {
     nonisolated let providerID = CloudStorageProviderID.googleDrive
     nonisolated let account: CloudStorageAccount
-    nonisolated let capabilities: CloudStorageProviderCapabilities = .readWrite
+    nonisolated let capabilities: CloudStorageProviderCapabilities = [
+        .createFile,
+        .updateFile,
+        .moveItem,
+        .deleteItem,
+    ]
 
     private let client: GoogleDriveAPIClient
-
     init(
         account: CloudStorageAccount,
         tokenProvider: any GoogleDriveAccessTokenProviding,

--- a/ExcalidrawZ/Persistence/CloudStorage/GoogleDrive/GoogleDriveConfiguration.swift
+++ b/ExcalidrawZ/Persistence/CloudStorage/GoogleDrive/GoogleDriveConfiguration.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 struct GoogleDriveConfiguration: Sendable {
-    static let driveScope = "https://www.googleapis.com/auth/drive"
+    static let driveScope = "https://www.googleapis.com/auth/drive.file"
 
     let clientID: String
     let redirectURI: URL

--- a/ExcalidrawZ/Persistence/CloudStorage/GoogleDrive/GoogleDriveCredentialStore.swift
+++ b/ExcalidrawZ/Persistence/CloudStorage/GoogleDrive/GoogleDriveCredentialStore.swift
@@ -13,8 +13,8 @@ struct GoogleDriveCredential: Codable, Sendable {
     let accessToken: String
     let refreshToken: String
     let expiresAt: Date
-    /// Nil identifies credentials created before ExcalidrawZ requested full
-    /// Drive access. Those credentials must be upgraded interactively.
+    /// Nil or a different Drive scope identifies credentials that must be
+    /// replaced interactively before they can be used by the current flow.
     let grantedScopes: Set<String>?
 
     var hasRequiredScope: Bool {

--- a/ExcalidrawZ/Persistence/CloudStorage/GoogleDrive/GoogleDriveModels.swift
+++ b/ExcalidrawZ/Persistence/CloudStorage/GoogleDrive/GoogleDriveModels.swift
@@ -11,10 +11,10 @@ struct GoogleDriveFile: Decodable, Sendable {
     struct Capabilities: Decodable, Sendable {
         let canDownload: Bool?
         let canAddChildren: Bool?
-        let canEdit: Bool?
+        let canModifyContent: Bool?
         let canRename: Bool?
         let canMoveItemWithinDrive: Bool?
-        let canDelete: Bool?
+        let canTrash: Bool?
     }
 
     let id: String
@@ -63,10 +63,10 @@ struct GoogleDriveFile: Decodable, Sendable {
         var result: CloudStorageItemCapabilities = []
         if capabilities.canDownload == true { result.insert(.download) }
         if capabilities.canAddChildren == true { result.insert(.createChildren) }
-        if capabilities.canEdit == true { result.insert(.updateContent) }
+        if capabilities.canModifyContent == true { result.insert(.updateContent) }
         if capabilities.canRename == true { result.insert(.rename) }
         if capabilities.canMoveItemWithinDrive == true { result.insert(.move) }
-        if capabilities.canDelete == true { result.insert(.delete) }
+        if capabilities.canTrash == true { result.insert(.delete) }
         if isFolder { result.remove(.download) }
         return result
     }

--- a/ExcalidrawZ/Persistence/CloudStorage/GoogleDrive/GoogleDriveOAuthAuthenticator.swift
+++ b/ExcalidrawZ/Persistence/CloudStorage/GoogleDrive/GoogleDriveOAuthAuthenticator.swift
@@ -36,6 +36,7 @@ final class GoogleDriveOAuthAuthenticator: NSObject, GoogleDriveAuthenticating {
 
     func accounts() async throws -> [CloudStorageAccount] {
         try credentialStore.credentials()
+            .filter(\.hasRequiredScope)
             .map(\.cloudStorageAccount)
             .sorted {
                 $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
@@ -43,18 +44,32 @@ final class GoogleDriveOAuthAuthenticator: NSObject, GoogleDriveAuthenticating {
     }
 
     func authorize() async throws -> CloudStorageAccount {
-        try await performAuthorization(accountHint: nil)
+        try await performAuthorization(
+            accountHint: nil,
+            pickerMode: .none,
+            folderIDHint: nil
+        ).account
     }
 
-    func accountWithRequiredScope(
-        accountHint: CloudStorageAccount?
-    ) async throws -> CloudStorageAccount {
-        if let accountHint,
-           let credential = try credentialStore.credential(for: accountHint.id),
-           credential.hasRequiredScope {
-            return credential.cloudStorageAccount
+    func authorizeAndSelectFolder(
+        accountHint: CloudStorageAccount?,
+        folderIDHint: CloudStorageItemID? = nil
+    ) async throws -> GoogleDriveFolderAuthorization {
+        // Every Google OnePick invocation requires a consent prompt. Keep root
+        // selection to one round; granting more files must be a separate action.
+        let result = try await performAuthorization(
+            accountHint: accountHint,
+            pickerMode: .folder,
+            folderIDHint: folderIDHint
+        )
+        guard let folderID = result.pickedItemIDs.first else {
+            throw CloudStorageError.authorizationCancelled
         }
-        return try await performAuthorization(accountHint: accountHint)
+
+        return GoogleDriveFolderAuthorization(
+            account: result.account,
+            folderID: folderID
+        )
     }
 
     func accessToken(for accountID: CloudStorageAccountID) async throws -> String {
@@ -127,14 +142,18 @@ final class GoogleDriveOAuthAuthenticator: NSObject, GoogleDriveAuthenticating {
     }
 
     private func performAuthorization(
-        accountHint: CloudStorageAccount?
-    ) async throws -> CloudStorageAccount {
+        accountHint: CloudStorageAccount?,
+        pickerMode: PickerMode,
+        folderIDHint: CloudStorageItemID?
+    ) async throws -> AuthorizationResult {
         let state = UUID().uuidString
         let verifier = try Self.makeCodeVerifier()
         let callbackURL = try await authenticate(
             state: state,
             codeChallenge: Self.codeChallenge(for: verifier),
-            accountHint: accountHint
+            accountHint: accountHint,
+            pickerMode: pickerMode,
+            folderIDHint: folderIDHint
         )
         let values = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false)?.queryItems ?? []
         guard values.first(where: { $0.name == "state" })?.value == state else {
@@ -151,6 +170,15 @@ final class GoogleDriveOAuthAuthenticator: NSObject, GoogleDriveAuthenticating {
                 "Google authorization did not return an authorization code."
             )
         }
+        let pickedItemIDs = values
+            .first(where: { $0.name == "picked_file_ids" })?
+            .value?
+            .split(separator: ",")
+            .map { CloudStorageItemID(rawValue: String($0)) }
+            ?? []
+        if case .folder = pickerMode, pickedItemIDs.isEmpty {
+            throw CloudStorageError.authorizationCancelled
+        }
 
         let token = try await requestToken(parameters: [
             "client_id": configuration.clientID,
@@ -162,9 +190,25 @@ final class GoogleDriveOAuthAuthenticator: NSObject, GoogleDriveAuthenticating {
         let user = try await currentUser(accessToken: token.accessToken)
         let accountID = CloudStorageAccountID(rawValue: user.permissionId)
         let existingCredential = try credentialStore.credential(for: accountID)
-        guard let refreshToken = token.refreshToken ?? existingCredential?.refreshToken else {
+        let reusableRefreshToken = existingCredential?.hasRequiredScope == true
+            ? existingCredential?.refreshToken
+            : nil
+        guard let refreshToken = token.refreshToken ?? reusableRefreshToken else {
             throw CloudStorageError.invalidProviderResponse(
                 "Google authorization did not return a refresh token. Revoke ExcalidrawZ access in your Google Account and try again."
+            )
+        }
+        let grantedScopeValue = values.first(where: { $0.name == "scope" })?.value
+            ?? GoogleDriveConfiguration.driveScope
+        let grantedScopes = Set(
+            grantedScopeValue
+                .replacingOccurrences(of: "+", with: " ")
+                .split(whereSeparator: { $0.isWhitespace })
+                .map(String.init)
+        )
+        guard grantedScopes.contains(GoogleDriveConfiguration.driveScope) else {
+            throw CloudStorageError.invalidProviderResponse(
+                "Google authorization did not grant access to files selected for ExcalidrawZ."
             )
         }
         let credential = GoogleDriveCredential(
@@ -174,16 +218,21 @@ final class GoogleDriveOAuthAuthenticator: NSObject, GoogleDriveAuthenticating {
             accessToken: token.accessToken,
             refreshToken: refreshToken,
             expiresAt: Date().addingTimeInterval(token.expiresIn),
-            grantedScopes: [GoogleDriveConfiguration.driveScope]
+            grantedScopes: grantedScopes
         )
         try credentialStore.save(credential)
-        return credential.cloudStorageAccount
+        return AuthorizationResult(
+            account: credential.cloudStorageAccount,
+            pickedItemIDs: pickedItemIDs
+        )
     }
 
     private func authenticate(
         state: String,
         codeChallenge: String,
-        accountHint: CloudStorageAccount?
+        accountHint: CloudStorageAccount?,
+        pickerMode: PickerMode,
+        folderIDHint: CloudStorageItemID?
     ) async throws -> URL {
         guard var components = URLComponents(
             url: configuration.authorizationURL,
@@ -205,6 +254,22 @@ final class GoogleDriveOAuthAuthenticator: NSObject, GoogleDriveAuthenticating {
             URLQueryItem(name: "code_challenge_method", value: "S256"),
             URLQueryItem(name: "state", value: state),
         ]
+        switch pickerMode {
+        case .none:
+            break
+        case .folder:
+            queryItems.append(contentsOf: [
+                URLQueryItem(name: "trigger_onepick", value: "true"),
+                URLQueryItem(name: "allow_folder_selection", value: "true"),
+                URLQueryItem(name: "allow_multiple", value: "false"),
+                URLQueryItem(name: "mimetypes", value: GoogleDriveFile.folderMIMEType),
+            ])
+            if let folderIDHint {
+                queryItems.append(
+                    URLQueryItem(name: "file_ids", value: folderIDHint.rawValue)
+                )
+            }
+        }
         if let loginHint = accountHint?.emailAddress {
             queryItems.append(URLQueryItem(name: "login_hint", value: loginHint))
         }
@@ -333,6 +398,16 @@ final class GoogleDriveOAuthAuthenticator: NSObject, GoogleDriveAuthenticating {
     nonisolated private static func codeChallenge(for verifier: String) -> String {
         Data(SHA256.hash(data: Data(verifier.utf8))).base64URLEncodedString()
     }
+}
+
+private struct AuthorizationResult {
+    let account: CloudStorageAccount
+    let pickedItemIDs: [CloudStorageItemID]
+}
+
+private enum PickerMode {
+    case none
+    case folder
 }
 
 extension GoogleDriveOAuthAuthenticator: ASWebAuthenticationPresentationContextProviding {

--- a/ExcalidrawZ/Persistence/LocalFolder+Persistence.swift
+++ b/ExcalidrawZ/Persistence/LocalFolder+Persistence.swift
@@ -324,6 +324,25 @@ extension LocalFolder {
             .folder
     }
 
+    static func deepestFolder(
+        containingLocalFileAt fileURL: URL,
+        in context: NSManagedObjectContext
+    ) throws -> LocalFolder? {
+        let parentURL = fileURL.deletingLastPathComponent().standardizedFileURL
+        let request = NSFetchRequest<LocalFolder>(entityName: "LocalFolder")
+
+        return try context.fetch(request)
+            .compactMap { folder -> (folder: LocalFolder, url: URL)? in
+                guard let folderPath = folder.filePath else { return nil }
+                let folderURL = URL(fileURLWithPath: folderPath, isDirectory: true)
+                    .standardizedFileURL
+                guard parentURL.isContained(in: folderURL) else { return nil }
+                return (folder, folderURL)
+            }
+            .max { $0.url.path.count < $1.url.path.count }?
+            .folder
+    }
+
     private static func securityScopedBookmarkData(forLocalFileAt fileURL: URL) async throws -> Data? {
         let context = PersistenceController.shared.newTaskContext()
 

--- a/ExcalidrawZ/Persistence/LocalFolder+Persistence.swift
+++ b/ExcalidrawZ/Persistence/LocalFolder+Persistence.swift
@@ -34,6 +34,8 @@ extension LocalFolder {
         [.withSecurityScope]
     }
 #elseif os(iOS)
+    // iOS document-picker bookmarks implicitly start their ephemeral security
+    // scope when resolved. The matching stop happens after each operation.
     var bookmarkResolutionOptions: URL.BookmarkResolutionOptions { [] }
     var bookmarkCreationOptions: URL.BookmarkCreationOptions { [] }
 #endif
@@ -80,14 +82,12 @@ extension LocalFolder {
     func refreshResolvedLocation(context: NSManagedObjectContext) throws -> ResolvedLocationChange? {
         guard parent == nil, let resolved = try resolvedBookmark() else { return nil }
 
+        try Self.beginResolvedBookmarkAccess(to: resolved.url)
+        defer { resolved.url.stopAccessingSecurityScopedResource() }
+
         let oldURL = (url ?? filePath.map { URL(fileURLWithPath: $0) })?.standardizedFileURL
         let locationChanged = oldURL != resolved.url
         guard locationChanged || resolved.isStale else { return nil }
-
-        guard resolved.url.startAccessingSecurityScopedResource() else {
-            throw StartAccessingSecurityScopedResourceError()
-        }
-        defer { resolved.url.stopAccessingSecurityScopedResource() }
 
         let change = try context.performAndWait { () throws -> ResolvedLocationChange? in
             let previousURL = (self.url ?? self.filePath.map { URL(fileURLWithPath: $0) })?
@@ -172,6 +172,70 @@ extension LocalFolder {
         var errorDescription: String? { "Start accessing security scoped resource failed." }
     }
 
+    private static func beginSecurityScopedAccess(to url: URL) throws {
+        guard url.startAccessingSecurityScopedResource() else {
+            throw StartAccessingSecurityScopedResourceError()
+        }
+    }
+
+    private static func beginResolvedBookmarkAccess(to url: URL) throws {
+#if os(macOS)
+        try beginSecurityScopedAccess(to: url)
+#elseif os(iOS)
+        // Resolving the document-picker bookmark starts access implicitly.
+        // Calling startAccessing again can return false even though the URL is
+        // accessible, so the resolved scope is balanced only by stop below.
+#endif
+    }
+
+    private static func isPendingUbiquitousDownload(_ url: URL) -> Bool {
+        let values = try? url.resourceValues(forKeys: [
+            .isUbiquitousItemKey,
+            .ubiquitousItemDownloadingStatusKey,
+        ])
+        return values?.isUbiquitousItem == true
+            && values?.ubiquitousItemDownloadingStatus == .notDownloaded
+    }
+
+    /// Returns nil while a File Provider-backed directory is still being
+    /// materialized. Callers must preserve their current UI or Core Data tree
+    /// instead of interpreting that state as an empty directory.
+    static func materializedDirectoryContents(
+        at url: URL,
+        includingPropertiesForKeys keys: [URLResourceKey]?,
+        options: FileManager.DirectoryEnumerationOptions = []
+    ) throws -> [URL]? {
+#if os(iOS)
+        if isPendingUbiquitousDownload(url) {
+            try? FileManager.default.startDownloadingUbiquitousItem(at: url)
+            return nil
+        }
+#endif
+
+        var contents = try FileManager.default.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: keys,
+            options: options
+        )
+
+#if os(iOS)
+        // Some File Provider implementations transiently return an empty first
+        // enumeration immediately after a bookmark is restored.
+        if contents.isEmpty {
+            contents = try FileManager.default.contentsOfDirectory(
+                at: url,
+                includingPropertiesForKeys: keys,
+                options: options
+            )
+            if contents.isEmpty, isPendingUbiquitousDownload(url) {
+                try? FileManager.default.startDownloadingUbiquitousItem(at: url)
+                return nil
+            }
+        }
+#endif
+        return contents
+    }
+
     private var securityScopeRoot: LocalFolder {
         var folder = self
         while let parent = folder.parent {
@@ -202,9 +266,7 @@ extension LocalFolder {
     @discardableResult
     public func withSecurityScopedURL<T>(actions: (_ scopedURL: URL) throws -> T) throws -> T {
         let urls = try resolvedAccessURLs()
-        guard urls.scope.startAccessingSecurityScopedResource() else {
-            throw StartAccessingSecurityScopedResourceError()
-        }
+        try Self.beginResolvedBookmarkAccess(to: urls.scope)
         defer { urls.scope.stopAccessingSecurityScopedResource() }
 
         return try actions(urls.target)
@@ -213,9 +275,7 @@ extension LocalFolder {
     @discardableResult
     public func withSecurityScopedURL<T>(actions: @escaping (_ scopedURL: URL) async throws -> T) async throws -> T {
         let urls = try resolvedAccessURLs()
-        guard urls.scope.startAccessingSecurityScopedResource() else {
-            throw StartAccessingSecurityScopedResourceError()
-        }
+        try Self.beginResolvedBookmarkAccess(to: urls.scope)
         defer { urls.scope.stopAccessingSecurityScopedResource() }
         return try await actions(urls.target)
     }
@@ -228,7 +288,13 @@ extension LocalFolder {
             return try await action()
         }
 
-        return try await withSecurityScopedBookmark(bookmarkData, action: action)
+        do {
+            return try await withSecurityScopedBookmark(bookmarkData, action: action)
+        } catch is StartAccessingSecurityScopedResourceError {
+            // A direct Files open can provide a valid file-scoped grant even
+            // when the saved containing-folder bookmark is unavailable.
+            return try await action()
+        }
     }
 
     static func modificationDate(forLocalFileAt fileURL: URL) async throws -> Date? {
@@ -239,33 +305,33 @@ extension LocalFolder {
         }
     }
 
+    static func rootFolder(
+        containing url: URL,
+        in context: NSManagedObjectContext
+    ) throws -> LocalFolder? {
+        let request = NSFetchRequest<LocalFolder>(entityName: "LocalFolder")
+        request.predicate = NSPredicate(format: "parent == nil")
+
+        return try context.fetch(request)
+            .compactMap { folder -> (folder: LocalFolder, rootURL: URL)? in
+                guard let folderPath = folder.filePath else { return nil }
+                let rootURL = URL(fileURLWithPath: folderPath, isDirectory: true)
+                    .standardizedFileURL
+                guard url.isContained(in: rootURL) else { return nil }
+                return (folder, rootURL)
+            }
+            .max { $0.rootURL.path.count < $1.rootURL.path.count }?
+            .folder
+    }
+
     private static func securityScopedBookmarkData(forLocalFileAt fileURL: URL) async throws -> Data? {
-        let filePath = fileURL.standardizedFileURL.path
         let context = PersistenceController.shared.newTaskContext()
 
         return try await context.perform {
-            let request = NSFetchRequest<LocalFolder>(entityName: "LocalFolder")
             // The picker grant belongs to a top-level linked folder and already
             // covers its descendants. Child bookmarks are navigation metadata;
             // using the root avoids provider-specific descendant bookmark behavior.
-            request.predicate = NSPredicate(format: "parent == nil")
-            let folders = try context.fetch(request)
-
-            return folders.compactMap { folder -> (path: String, bookmarkData: Data)? in
-                guard let folderPath = folder.filePath,
-                      let bookmarkData = folder.bookmarkData else {
-                    return nil
-                }
-
-                let standardizedFolderPath = URL(fileURLWithPath: folderPath).standardizedFileURL.path
-                guard Self.filePath(filePath, isContainedInFolderPath: standardizedFolderPath) else {
-                    return nil
-                }
-
-                return (standardizedFolderPath, bookmarkData)
-            }
-            .max { $0.path.count < $1.path.count }?
-            .bookmarkData
+            return try rootFolder(containing: fileURL, in: context)?.bookmarkData
         }
     }
 
@@ -285,16 +351,10 @@ extension LocalFolder {
             bookmarkDataIsStale: &isStale
         )
 
-        guard scopedURL.startAccessingSecurityScopedResource() else {
-            throw StartAccessingSecurityScopedResourceError()
-        }
+        try beginResolvedBookmarkAccess(to: scopedURL)
         defer { scopedURL.stopAccessingSecurityScopedResource() }
 
         return try await action()
-    }
-
-    private static func filePath(_ filePath: String, isContainedInFolderPath folderPath: String) -> Bool {
-        filePath == folderPath || filePath.hasPrefix(folderPath + "/")
     }
 
     private static func localFolder(
@@ -316,13 +376,16 @@ extension LocalFolder {
         return child
     }
     
-    func refreshChildren(context: NSManagedObjectContext) throws {
+    func refreshChildren(
+        context: NSManagedObjectContext,
+        recursively: Bool = true
+    ) throws {
         try refreshResolvedLocation(context: context)
         try self.withSecurityScopedURL { url in
-            let contents = try FileManager.default.contentsOfDirectory(
+            guard let contents = try Self.materializedDirectoryContents(
                 at: url,
                 includingPropertiesForKeys: [.nameKey, .isHiddenKey]
-            )
+            ) else { return }
             try context.performAndWait {
                 let fetchRequest = NSFetchRequest<LocalFolder>(entityName: "LocalFolder")
                 fetchRequest.predicate = NSPredicate(format: "parent = %@", self)
@@ -357,8 +420,10 @@ extension LocalFolder {
                     try deleteLocalFolder(folder, context: context)
                 }
                 
-                for case let subfolder as LocalFolder in self.children?.allObjects ?? [] {
-                    try subfolder.refreshChildren(context: context)
+                if recursively {
+                    for case let subfolder as LocalFolder in self.children?.allObjects ?? [] {
+                        try subfolder.refreshChildren(context: context)
+                    }
                 }
                 
                 try context.save()

--- a/ExcalidrawZ/Settings/CloudStorageSettingsView.swift
+++ b/ExcalidrawZ/Settings/CloudStorageSettingsView.swift
@@ -32,22 +32,23 @@ struct CloudStorageSettingsView: View {
                     }
                 }
             } header: {
-                Text("Connected Accounts")
+                Text(.localizable(.cloudStorageConnectedAccounts))
             } footer: {
-                Text("Disconnecting removes this account, its linked folders, and local caches from ExcalidrawZ. Files stored in the cloud are not deleted.")
+                Text(.localizable(.settingsCloudStorageDisconnectDescription))
             }
         }
-        .navigationTitle("Connected Accounts")
+        .navigationTitle(.localizable(.cloudStorageConnectedAccounts))
         .task {
             await connections.refresh()
         }
         .alert(item: $disconnectRequest) { entry in
             Alert(
-                title: Text("Disconnect Account?"),
-                message: Text(
-                    "Disconnect \(entry.account.displayName) from \(entry.providerName)? All linked folders for this account will be removed from ExcalidrawZ."
-                ),
-                primaryButton: .destructive(Text("Disconnect")) {
+                title: Text(.localizable(.settingsCloudStorageDisconnectTitle)),
+                message: Text(.localizable(.settingsCloudStorageDisconnectMessage(
+                    entry.account.displayName,
+                    entry.providerName
+                ))),
+                primaryButton: .destructive(Text(.localizable(.settingsCloudStorageDisconnectAction))) {
                     disconnect(entry)
                 },
                 secondaryButton: .cancel()
@@ -70,9 +71,9 @@ struct CloudStorageSettingsView: View {
                 .foregroundStyle(.secondary)
 
             VStack(alignment: .leading, spacing: 3) {
-                Text("No Connected Accounts")
+                Text(.localizable(.settingsCloudStorageNoConnectedAccounts))
                     .font(.headline)
-                Text("Connect a cloud storage provider from Linked Storage in the sidebar.")
+                Text(.localizable(.settingsCloudStorageNoConnectedAccountsDescription))
                     .font(.callout)
                     .foregroundStyle(.secondary)
             }
@@ -106,7 +107,7 @@ struct CloudStorageSettingsView: View {
                 ProgressView()
                     .controlSize(.small)
             } else {
-                Button("Disconnect", role: .destructive) {
+                Button(.localizable(.settingsCloudStorageDisconnectAction), role: .destructive) {
                     disconnectRequest = entry
                 }
                 .buttonStyle(.bordered)

--- a/ExcalidrawZ/Settings/SettingsView.swift
+++ b/ExcalidrawZ/Settings/SettingsView.swift
@@ -258,7 +258,7 @@ extension SettingsView {
                 case .security:
                     return .localizable(.settingsSecurityName)
                 case .cloudStorage:
-                    return "Connected Accounts"
+                    return .localizable(.cloudStorageConnectedAccounts)
                 case .ai:
                     // TODO: localize once a key is added.
                     return "AI"

--- a/ExcalidrawZ/Share/ShareToolbarButton.swift
+++ b/ExcalidrawZ/Share/ShareToolbarButton.swift
@@ -48,14 +48,14 @@ struct ShareToolbarButton: View {
 #endif
 
     private var isShareDisabled: Bool {
-        if fileState.currentActiveFile == nil {
+        guard let activeFile = fileState.currentActiveFile else {
             return true
         }
         if fileState.activeCollaborationFileIsLoading {
             return true
         }
-        if case .group(let group) = fileState.currentActiveGroup {
-            return group.groupType == .trash
+        if case .file(let file) = activeFile {
+            return file.inTrash
         }
         return false
     }
@@ -146,11 +146,12 @@ struct ShareToolbarButton: View {
                     )
                     self.shareFileState.currentSharedFile = excalidrawFile
                 case .localFile(let url):
-                    if case .localFolder(let folder) = fileState.currentActiveGroup {
-                        try await folder.withSecurityScopedURL { (_: URL) async throws -> Void in
-                            self.shareFileState.currentSharedFile = try ExcalidrawFile(contentsOf: url)
-                        }
+                    let excalidrawFile = try await LocalFolder.withSecurityScopedAccessToContainingFolder(
+                        for: url
+                    ) {
+                        try ExcalidrawFile(contentsOf: url)
                     }
+                    self.shareFileState.currentSharedFile = excalidrawFile
                 case .temporaryFile(let url):
                     let content = try await fileState.readTemporaryFileContent(at: url)
                     self.shareFileState.currentSharedFile = try ExcalidrawFile(

--- a/ExcalidrawZ/Share/ShareToolbarButton.swift
+++ b/ExcalidrawZ/Share/ShareToolbarButton.swift
@@ -152,7 +152,11 @@ struct ShareToolbarButton: View {
                         }
                     }
                 case .temporaryFile(let url):
-                    self.shareFileState.currentSharedFile = try ExcalidrawFile(contentsOf: url)
+                    let content = try await fileState.readTemporaryFileContent(at: url)
+                    self.shareFileState.currentSharedFile = try ExcalidrawFile(
+                        data: content,
+                        id: fileState.currentActiveFile?.id
+                    )
                     
                 case .collaborationFile(let collaborationFile):
                     let content = try await collaborationFile.loadContent()

--- a/ExcalidrawZ/Sidebar/CloudStorageItemContextMenu.swift
+++ b/ExcalidrawZ/Sidebar/CloudStorageItemContextMenu.swift
@@ -408,6 +408,7 @@ struct CloudStorageFolderActionsModifier: ViewModifier {
     @EnvironmentObject private var fileState: FileState
 
     @ObservedObject private var documentStore = CloudStorageDocumentStore.shared
+    @ObservedObject private var connections = CloudStorageConnectionStore.shared
 
     let folder: CloudStorageFolderReference
     let presentation: Presentation
@@ -475,7 +476,7 @@ struct CloudStorageFolderActionsModifier: ViewModifier {
             }
         }
 
-        if capabilities.contains(.createChildren) {
+        if documentStore.canCreateFolder(in: folder, connections: connections) {
             Button {
                 newFolderName = documentStore.availableFolderName(in: folder)
                 isCreateFolderPresented = true

--- a/ExcalidrawZ/Sidebar/GroupListView.swift
+++ b/ExcalidrawZ/Sidebar/GroupListView.swift
@@ -536,7 +536,6 @@ struct ImportFilesModifier: ViewModifier {
 }
 
 struct ImportLocalFolderModifier: ViewModifier {
-    @Environment(\.alert) private var alert
     @Environment(\.alertToast) private var alertToast
     
     @Binding var isImportLocalFolderDialogPresented: Bool
@@ -556,74 +555,38 @@ struct ImportLocalFolderModifier: ViewModifier {
             }
     }
     
-    private struct FolderTooLargeError: LocalizedError {
-        var errorDescription: String? {
-            .init(localizable: .sidebarLocalFolderTooLargeAlertDescription)
-        }
-    }
-    
     private func importLocalFolders(urls: [URL]) {
         let context = PersistenceController.shared.container.newBackgroundContext()
         Task.detached {
             do {
-                let request = NSFetchRequest<LocalFolder>(entityName: "LocalFolder")
-                let folders = try context.fetch(request)
-                
-                for url in urls where folders.contains(where: { $0.url == url }) == false {
-                    guard url.startAccessingSecurityScopedResource() else { continue }
+                for url in urls {
+                    guard url.startAccessingSecurityScopedResource() else {
+                        throw AppError.urlError(.startAccessingSecurityScopedResourceFailed)
+                    }
                     defer { url.stopAccessingSecurityScopedResource() }
-                    
-                    guard let enumerator = FileManager.default.enumerator(
-                        at: url,
-                        includingPropertiesForKeys: [.isDirectoryKey, .nameKey, .isHiddenKey]
-                    ) else {
-                        return
-                    }
-                    
-                    var urls: [URL] = []
-                    var count = 0
-                    while let itemURL = enumerator.nextObject() as? URL {
-                        let resourceValues = try? itemURL.resourceValues(forKeys: [.isDirectoryKey, .isHiddenKey])
-                        let isHidden = resourceValues?.isHidden ?? false
-                        let isDirectory = resourceValues?.isDirectory ?? false
-                        
-                        if isHidden {
-                            if isDirectory {
-                                enumerator.skipDescendants()
-                            }
-                            continue
-                        }
-                        
-                        urls.append(itemURL)
-                        if isDirectory {
-                            count += 1
-                        }
-                    }
-                    
-                    if count > 1000 {
-                        await MainActor.run {
-                            alert(
-                                title: .init(localizable: .sidebarLocalFolderTooLargeAlertTitle),
-                                error: FolderTooLargeError()
+
+                    try await context.perform {
+                        let request = NSFetchRequest<LocalFolder>(entityName: "LocalFolder")
+                        request.predicate = NSPredicate(
+                            format: "parent == nil AND filePath == %@",
+                            url.standardizedFileURL.filePath
+                        )
+                        request.fetchLimit = 1
+                        if let existing = try context.fetch(request).first {
+                            // Re-linking is also the recovery path for an old
+                            // or provider-invalidated bookmark.
+                            existing.url = url.standardizedFileURL
+                            existing.filePath = url.standardizedFileURL.filePath
+                            existing.bookmarkData = try url.bookmarkData(
+                                options: existing.bookmarkCreationOptions,
+                                includingResourceValuesForKeys: [.nameKey],
+                                relativeTo: nil
                             )
+                            try context.save()
+                            return
                         }
-                        return
-                    }
-                    
-                    try await context.perform { [urls] in
-                        let localFolder = try LocalFolder(url: url, context: context)
-                        context.insert(localFolder)
-                        try localFolder.refreshChildren(context: context)
-                        // create checkpoints for every file in folder
-                        for url in urls {
-                            if url.pathExtension == "excalidraw" {
-                                let checkpoint = LocalFileCheckpoint(context: context)
-                                checkpoint.url = url
-                                checkpoint.content = try Data(contentsOf: url)
-                                checkpoint.updatedAt = .now
-                                context.insert(checkpoint)
-                            }
-                        }
+
+                        _ = try LocalFolder(url: url, context: context)
                         try context.save()
                     }
                 }

--- a/ExcalidrawZ/Sidebar/GroupListView.swift
+++ b/ExcalidrawZ/Sidebar/GroupListView.swift
@@ -420,7 +420,6 @@ fileprivate struct ContentHeaderCreateButtonModifier: ViewModifier {
     }
     
     @State private var isImportLocalFolderDialogPresented = false
-    @State private var isImportFilesDialogPresented = false
     @State private var isCreateGroupDialogPresented = false
     @State private var isHovered = false
 
@@ -448,36 +447,20 @@ fileprivate struct ContentHeaderCreateButtonModifier: ViewModifier {
                         Button {
                              isImportLocalFolderDialogPresented.toggle()
                         } label: {
-                            Label(.localizable(.fileHomeButtonCreateNewFolder), systemSymbol: .plusCircleFill)
+                            SidebarSectionAddIcon(
+                                accessibilityLabel: Text(.localizable(.fileHomeButtonCreateNewFolder))
+                            )
                         }
                         // Two file importers can not be called in same place
                         .modifier(ImportLocalFolderModifier(isPresented: $isImportLocalFolderDialogPresented))
                     case .group:
-                        Menu {
-                            SwiftUI.Group {
-                                Button {
-                                    isCreateGroupDialogPresented.toggle()
-                                } label: {
-                                    Label(.localizable(.fileHomeButtonCreateNewGroup), systemSymbol: .plusCircleFill)
-                                }
-
-                                // New: Use fileImporter for cross-platform support
-                                Button {
-                                    isImportFilesDialogPresented.toggle()
-                                } label: {
-                                    Label(
-                                        .localizable(.menubarButtonImport),
-                                        systemSymbol: .squareAndArrowDown
-                                    )
-                                }
-                            }
-                            .labelStyle(.titleAndIcon)
+                        Button {
+                            isCreateGroupDialogPresented.toggle()
                         } label: {
-                            Label(.localizable(.fileHomeButtonCreateNewGroup), systemSymbol: .plusCircleFill)
+                            SidebarSectionAddIcon(
+                                accessibilityLabel: Text(.localizable(.fileHomeButtonCreateNewGroup))
+                            )
                         }
-                        .menuIndicator(.hidden)
-                        .fixedSize()
-                        .modifier(ImportFilesModifier(isPresented: $isImportFilesDialogPresented))
                         .modifier(
                             CreateGroupModifier(
                                 isPresented: $isCreateGroupDialogPresented,
@@ -492,47 +475,16 @@ fileprivate struct ContentHeaderCreateButtonModifier: ViewModifier {
             .controlSize(.large)
             .padding(.trailing, 2)
 #endif
-#if os(iOS)
-            .tint(.secondary)
-#endif
             .labelStyle(.iconOnly)
             .buttonStyle(.borderless)
             .opacity(isHovered ? 1 : 0.4)
         }
+        .frame(maxWidth: .infinity)
         .font(.callout.bold())
         .animation(.smooth, value: isHovered)
 
     }
     
-}
-
-struct ImportFilesModifier: ViewModifier {
-    @Binding var isImportFilesDialogPresented: Bool
-    
-    init(isPresented: Binding<Bool>) {
-        self._isImportFilesDialogPresented = isPresented
-    }
-    
-    func body(content: Content) -> some View {
-        content
-            .fileImporterWithAlert(
-                isPresented: $isImportFilesDialogPresented,
-                allowedContentTypes: [
-                    .init(filenameExtension: "excalidraw") ?? .excalidrawFile,
-                    .excalidrawPNG,
-                    .excalidrawSVG,
-                    .png,
-                    .svg,
-                    .folder  // Also allow directory selection
-                ],
-                allowsMultipleSelection: true
-            ) { urls in
-                NotificationCenter.default.post(
-                    name: .shouldHandleImport,
-                    object: urls
-                )
-            }
-    }
 }
 
 struct ImportLocalFolderModifier: ViewModifier {

--- a/ExcalidrawZ/Sidebar/LinkedStorageAddMenu.swift
+++ b/ExcalidrawZ/Sidebar/LinkedStorageAddMenu.swift
@@ -109,7 +109,7 @@ struct LinkedStorageAddMenu<AdditionalContent: View, Label: View>: View {
                 localized: "linkedStorageCloudStorageSection",
                 defaultValue: "Or Cloud Storage"
             )) {
-                ForEach(connections.providerDescriptors, id: \.id) { descriptor in
+                ForEach(availableProviderDescriptors, id: \.id) { descriptor in
                     Button {
                         addLocation(to: descriptor.id)
                     } label: {
@@ -129,6 +129,10 @@ struct LinkedStorageAddMenu<AdditionalContent: View, Label: View>: View {
 
     private var isLoading: Bool {
         preparingProviderID != nil || !connections.connectingProviderIDs.isEmpty
+    }
+
+    private var availableProviderDescriptors: [CloudStorageProviderDescriptor] {
+        connections.providerDescriptors.filter { $0.id != .googleDrive }
     }
 
     private func addLocation(to providerID: CloudStorageProviderID) {

--- a/ExcalidrawZ/Sidebar/LinkedStorageSidebarSection.swift
+++ b/ExcalidrawZ/Sidebar/LinkedStorageSidebarSection.swift
@@ -79,6 +79,7 @@ struct LinkedStorageSidebarSection: View {
                         .transition(.scale(scale: 0, anchor: .topTrailing).combined(with: .opacity))
                 }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(Rectangle())
             .onHover { isHovered = $0 }
             .animation(.smooth, value: showEmptyPlaceholder)
@@ -114,12 +115,11 @@ struct LinkedStorageSidebarSection: View {
                     ProgressView()
                         .controlSize(.mini)
                 } else {
-                    Label(
-                        String(
+                    SidebarSectionAddIcon(
+                        accessibilityLabel: Text(String(
                             localized: "linkedStorageAddStorage",
                             defaultValue: "Add Storage"
-                        ),
-                        systemImage: "plus.circle.fill"
+                        ))
                     )
                 }
             }
@@ -132,10 +132,8 @@ struct LinkedStorageSidebarSection: View {
             .padding(.trailing, 2)
 #endif
         }
+        .frame(maxWidth: .infinity)
         .font(.callout.bold())
-#if os(iOS)
-        .tint(.secondary)
-#endif
         .animation(.smooth, value: isHovered)
     }
 

--- a/ExcalidrawZ/Sidebar/LinkedStorageSidebarSection.swift
+++ b/ExcalidrawZ/Sidebar/LinkedStorageSidebarSection.swift
@@ -269,7 +269,6 @@ struct LinkedStorageSidebarSection: View {
 
     private static let supportedProviderIDs: [CloudStorageProviderID] = [
         .microsoftOneDrive,
-        .googleDrive,
         .dropbox,
         .webDAV,
     ]

--- a/ExcalidrawZ/Sidebar/Local/LocalFilesProvider.swift
+++ b/ExcalidrawZ/Sidebar/Local/LocalFilesProvider.swift
@@ -87,7 +87,7 @@ struct LocalFilesProvider<Content: View>: View {
                         getFolderContents()
                         if fileState.currentActiveFile == nil || {
                             if case .localFile(let localFile) = fileState.currentActiveFile {
-                                return localFile.deletingLastPathComponent() != folder.url
+                                return !isDirectChildOfCurrentFolder(localFile)
                             } else {
                                 return true
                             }
@@ -108,7 +108,7 @@ struct LocalFilesProvider<Content: View>: View {
                 sortFiles(field: newValue)
             }
             .onReceive(localFolderState.itemCreatedPublisher) { path in
-                getFolderContents()
+                handleItemCreated(path: path)
             }
             .onReceive(localFolderState.itemRemovedPublisher) { path in
                 handleItemRemoved(path: path)
@@ -124,10 +124,13 @@ struct LocalFilesProvider<Content: View>: View {
             }
             .onReceive(localFolderState.refreshFilesPublisher) { _ in
                 getFolderContents()
-                if case .localFile(let file) = fileState.currentActiveFile,
-                   !files.contains(file) {
-                    fileState.setActiveFile(nil)
-                }
+            }
+            .onReceive(
+                NotificationCenter.default.publisher(for: .localFolderAvailabilityDidChange)
+            ) { notification in
+                guard let folderID = notification.object as? NSManagedObjectID,
+                      folderID == folder.objectID else { return }
+                getFolderContents()
             }
     }
 
@@ -158,18 +161,18 @@ struct LocalFilesProvider<Content: View>: View {
         DispatchQueue.main.async {
             do {
                 try folder.withSecurityScopedURL { folderURL in
-                    let contents = try FileManager.default.contentsOfDirectory(
+                    guard let contents = try LocalFolder.materializedDirectoryContents(
                         at: folderURL,
                         includingPropertiesForKeys: [
-                            .nameKey, 
-                            .contentModificationDateKey, 
+                            .nameKey,
+                            .contentModificationDateKey,
                             .creationDateKey,
                             .ubiquitousItemDownloadingStatusKey,
                             .isUbiquitousItemKey
                         ],
                         options: [.skipsSubdirectoryDescendants]
-                    )
-                    let files = contents
+                    ) else { return }
+                    var files = contents
                         .filter({
                             $0.pathExtension == "excalidraw"
                             || ($0.pathExtension == "svg" && $0.deletingPathExtension().pathExtension == "excalidraw")
@@ -190,6 +193,19 @@ struct LocalFilesProvider<Content: View>: View {
                             
                             return false
                         })
+
+                    // File Provider-backed folders may return a URL instance
+                    // that differs from the one used to create and open the
+                    // file even though both identify the same path. Keep the
+                    // active URL as the list identity so sidebar selection,
+                    // cover keys, and editor saves stay attached to one file.
+                    if case .localFile(let activeURL) = fileState.currentActiveFile {
+                        files = files.map { listedURL in
+                            listedURL.hasSameFileSystemPath(as: activeURL)
+                                ? activeURL
+                                : listedURL
+                        }
+                    }
                     self.sortValues = Dictionary(
                         uniqueKeysWithValues: files.map { file in
                             let values = try? file.resourceValues(
@@ -209,14 +225,6 @@ struct LocalFilesProvider<Content: View>: View {
                         self.files = files
                         self.sortFiles(field: self.sortField)
                         LocalFilesProviderCache.setFiles(self.files, for: folderCacheKey)
-                        
-                        if case .localFolder(let folder) = fileState.currentActiveGroup,
-                           folder == self.folder,
-                           case .localFile(let currentFile) = fileState.currentActiveFile {
-                            if !files.contains(currentFile) {
-                                fileState.setActiveFile(nil)
-                            }
-                        }
                     }
                     self.updateFlags = files.map {
                         [$0 : Date()]
@@ -236,6 +244,32 @@ struct LocalFilesProvider<Content: View>: View {
                 createdAt: nil
             )
         }
+    }
+
+    private func handleItemCreated(path: String) {
+        let fileURL = URL(fileURLWithPath: path)
+        guard isDirectChildOfCurrentFolder(fileURL) else { return }
+
+        if !files.contains(where: { $0.hasSameFileSystemPath(as: fileURL) }) {
+            let values = try? fileURL.resourceValues(
+                forKeys: [.contentModificationDateKey, .creationDateKey]
+            )
+            sortValues[fileURL] = ExcalidrawFileSortProvider.Values(
+                name: fileURL.deletingPathExtension().lastPathComponent,
+                updatedAt: values?.contentModificationDate,
+                createdAt: values?.creationDate
+            )
+            files.append(fileURL)
+            sortFiles(field: sortField)
+            updateFlags[fileURL] = Date()
+            LocalFilesProviderCache.setFiles(files, for: folderCacheKey)
+        }
+    }
+
+    private func isDirectChildOfCurrentFolder(_ fileURL: URL) -> Bool {
+        guard let folderPath = folder.filePath else { return false }
+        let folderURL = URL(fileURLWithPath: folderPath, isDirectory: true)
+        return fileURL.deletingLastPathComponent().hasSameFileSystemPath(as: folderURL)
     }
     
     private func handleItemRemoved(path: String) {

--- a/ExcalidrawZ/Sidebar/Local/LocalFolderAvailabilityIndicator.swift
+++ b/ExcalidrawZ/Sidebar/Local/LocalFolderAvailabilityIndicator.swift
@@ -1,0 +1,89 @@
+import CoreData
+import SFSafeSymbols
+import SwiftUI
+
+extension Notification.Name {
+    static let localFolderAvailabilityDidChange = Notification.Name(
+        "localFolderAvailabilityDidChange"
+    )
+}
+
+/// Reports materialization of a Linked Folder supplied by iCloud Drive or
+/// another Files provider. A successful download asks active file browsers to
+/// enumerate the folder again.
+@MainActor
+struct LocalFolderAvailabilityIndicator: View {
+    @Environment(\.scenePhase) private var scenePhase
+
+    let folder: LocalFolder
+
+    @State private var status: ICloudFileStatus?
+
+    var body: some View {
+        ZStack {
+            switch status {
+                case .notDownloaded, .outdated:
+                    statusIcon(.icloudAndArrowDown)
+                case .downloading:
+                    ProgressView()
+                        .controlSize(.mini)
+                        .frame(width: 16, height: 16)
+                case .error:
+                    statusIcon(.exclamationmarkTriangle)
+                default:
+                    EmptyView()
+            }
+        }
+        .task(id: monitorID) {
+            await monitorAvailability()
+        }
+    }
+
+    private var monitorID: String {
+        "\(folder.filePath ?? folder.objectID.uriRepresentation().absoluteString)|\(scenePhase)"
+    }
+
+    private func statusIcon(_ symbol: SFSymbol) -> some View {
+        Image(systemSymbol: symbol)
+            .foregroundStyle(.secondary)
+            .font(.footnote)
+            .frame(width: 16, height: 16)
+    }
+
+    private func monitorAvailability() async {
+        var wasWaitingForDownload = false
+
+        for _ in 0..<40 where !Task.isCancelled {
+            do {
+                let nextStatus = try await folder.withSecurityScopedURL { url in
+                    let checkedStatus = try await ICloudStatusChecker.shared.checkStatus(for: url)
+                    if checkedStatus == .notDownloaded || checkedStatus == .outdated {
+                        try FileManager.default.startDownloadingUbiquitousItem(at: url)
+                        return ICloudFileStatus.downloading(progress: nil)
+                    }
+                    return checkedStatus
+                }
+
+                status = nextStatus
+                if nextStatus.isInProgress {
+                    wasWaitingForDownload = true
+                    try await Task.sleep(nanoseconds: 750_000_000)
+                    continue
+                }
+
+                if wasWaitingForDownload, nextStatus.isAvailable {
+                    NotificationCenter.default.post(
+                        name: .localFolderAvailabilityDidChange,
+                        object: folder.objectID
+                    )
+                }
+                return
+            } catch is CancellationError {
+                return
+            } catch {
+                status = .error(error.localizedDescription)
+                return
+            }
+        }
+    }
+}

--- a/ExcalidrawZ/Sidebar/Local/LocalFolderMonitorModifier.swift
+++ b/ExcalidrawZ/Sidebar/Local/LocalFolderMonitorModifier.swift
@@ -71,10 +71,16 @@ struct LocalFolderMonitorModifier: ViewModifier {
         fileState.rebaseLinkedFolderSession(from: oldURL, to: newURL)
 
         guard registeredFolders.contains(folderID) else { return }
+        let resolvedObject = try? viewContext.existingObject(with: folderID)
+        let bookmarkData = (resolvedObject as? LocalFolder)?.bookmarkData
         Task {
             await FileSyncCoordinator.shared.removeFolder(at: oldURL)
             do {
-                try await FileSyncCoordinator.shared.addFolder(at: newURL, options: .default)
+                try await FileSyncCoordinator.shared.addFolder(
+                    at: newURL,
+                    options: .default,
+                    securityScopeBookmarkData: bookmarkData
+                )
                 await MainActor.run {
                     folderURLs[folderID] = newURL
                 }
@@ -108,11 +114,16 @@ struct LocalFolderMonitorModifier: ViewModifier {
                 continue
             }
 
+            let bookmarkData = folder.bookmarkData
             registeringFolders.insert(folderID)
             Task {
                 do {
                     try await folder.withSecurityScopedURL { scopedURL in
-                        try await FileSyncCoordinator.shared.addFolder(at: scopedURL, options: .default)
+                        try await FileSyncCoordinator.shared.addFolder(
+                            at: scopedURL,
+                            options: .default,
+                            securityScopeBookmarkData: bookmarkData
+                        )
                         await MainActor.run {
                             folderURLs[folderID] = scopedURL
                             registeredFolders.insert(folderID)

--- a/ExcalidrawZ/Sidebar/Local/LocalFolderRowView.swift
+++ b/ExcalidrawZ/Sidebar/Local/LocalFolderRowView.swift
@@ -62,14 +62,7 @@ struct LocalFolderRowView: View {
     @ViewBuilder
     private func content() -> some View {
         if folderStructStyle == .disclosureGroup {
-            HStack(spacing: 6) {
-                Image(systemSymbol: .folderFill)
-                    .foregroundStyle(Color(red: 12/255.0, green: 157/255.0, blue: 229/255.0))
-                Text(folder.url?.lastPathComponent ?? String(localizable: .generalUnknown))
-            }
-            .lineLimit(1)
-            .truncationMode(.middle)
-            .contentShape(Rectangle())
+            folderLabel
         } else {
             Button {
                 // Check if folder path exists using shared method
@@ -84,17 +77,23 @@ struct LocalFolderRowView: View {
                     showFolderNotFoundAlert = true
                 }
             } label: {
-                HStack(spacing: 6) {
-                    Image(systemSymbol: .folderFill)
-                        .foregroundStyle(Color(red: 12/255.0, green: 157/255.0, blue: 229/255.0))
-                    Text(folder.url?.lastPathComponent ?? String(localizable: .generalUnknown))
-                }
-                .lineLimit(1)
-                .truncationMode(.middle)
-                .contentShape(Rectangle())
+                folderLabel
             }
             .buttonStyle(.excalidrawSidebarRow(isSelected: isSelected, isMultiSelected: false))
         }
+    }
+
+    private var folderLabel: some View {
+        HStack(spacing: 6) {
+            Image(systemSymbol: .folderFill)
+                .foregroundStyle(Color(red: 12/255.0, green: 157/255.0, blue: 229/255.0))
+            Text(folder.url?.lastPathComponent ?? String(localizable: .generalUnknown))
+            Spacer(minLength: 0)
+            LocalFolderAvailabilityIndicator(folder: folder)
+        }
+        .lineLimit(1)
+        .truncationMode(.middle)
+        .contentShape(Rectangle())
     }
     
 }

--- a/ExcalidrawZ/Sidebar/Local/LocalFoldersView.swift
+++ b/ExcalidrawZ/Sidebar/Local/LocalFoldersView.swift
@@ -96,6 +96,9 @@ struct LocalFoldersView: View {
         } message: {
             Text(folderNotFoundMessage)
         }
+        .task(id: folder.objectID) {
+            await refreshImmediateChildren()
+        }
     }
     
     var dragItemURL: URL? {
@@ -251,6 +254,23 @@ struct LocalFoldersView: View {
             }
         }
     }
+
+    private func refreshImmediateChildren() async {
+        let folderID = folder.objectID
+        let context = PersistenceController.shared.newTaskContext()
+
+        do {
+            try await context.perform {
+                guard let folder = try context.existingObject(with: folderID) as? LocalFolder else {
+                    return
+                }
+                try folder.refreshChildren(context: context, recursively: false)
+            }
+        } catch is CancellationError {
+            return
+        } catch {
+            alertToast(error)
+        }
+    }
     
 }
-

--- a/ExcalidrawZ/Sidebar/components/CreateGroupSheetView.swift
+++ b/ExcalidrawZ/Sidebar/components/CreateGroupSheetView.swift
@@ -136,22 +136,27 @@ struct CreateGroupSheetView: View {
     @FocusState private var isFieldFocused: Bool
     
     var body: some View {
-        if #available(macOS 13.0, *) {
+        SwiftUI.Group {
+            if #available(macOS 13.0, *) {
 #if os(iOS)
-            if containerHorizontalSizeClass == .compact {
-                NavigationStack {
+                if containerHorizontalSizeClass == .compact {
+                    NavigationStack {
+                        content()
+                    }
+                } else {
                     content()
                 }
+#else
+                content()
+#endif
             } else {
                 content()
+                    .frame(width: 400)
             }
-#else
-            content()
-#endif
-        } else {
-            content()
-                .frame(width: 400)
         }
+        // A presenting button can carry an environment-based style (for
+        // example File Home's glass quick actions) into the sheet.
+        .buttonStyle(.automatic)
     }
     
 

--- a/ExcalidrawZ/Sidebar/components/GroupContextMenu.swift
+++ b/ExcalidrawZ/Sidebar/components/GroupContextMenu.swift
@@ -347,6 +347,7 @@ struct GroupMenuItems: View {
     var onToggleRename: () -> Void
     var onToogleCreateSubfolder: () -> Void
     var onToggleDelete: () -> Void
+    var onImportFiles: (() -> Void)?
     
     
     @FetchRequest
@@ -357,13 +358,15 @@ struct GroupMenuItems: View {
         canExpand: Bool,
         onToggleRename: @escaping () -> Void,
         onToogleCreateSubfolder: @escaping () -> Void,
-        onToggleDelete: @escaping () -> Void
+        onToggleDelete: @escaping () -> Void,
+        onImportFiles: (() -> Void)? = nil
     ) {
         self.group = group
         self.canExpand = canExpand
         self.onToggleRename = onToggleRename
         self.onToogleCreateSubfolder = onToogleCreateSubfolder
         self.onToggleDelete = onToggleDelete
+        self.onImportFiles = onImportFiles
         
         self._childrenGroups = FetchRequest(
             sortDescriptors: [SortDescriptor(\Group.name, order: .forward)],
@@ -381,89 +384,122 @@ struct GroupMenuItems: View {
     
     var body: some View {
         if group.groupType != .trash {
-            Button {
-                onToggleRename()
-            } label: {
-                if #available(macOS 13.0, *) {
-                    Label(
-                        .localizable(.sidebarGroupRowContextMenuRename),
-                        systemSymbol: .pencilLine
-                    )
-                } else {
-                    // Fallback on earlier versions
-                    Label(.localizable(.sidebarGroupRowContextMenuRename), systemSymbol: .pencil)
-                }
-            }
-            
-            Button {
-                onToogleCreateSubfolder()
-            } label: {
-                Label(.localizable(.sidebarGroupRowContextMenuAddSubgroup), systemSymbol: .folderBadgePlus)
-            }
-            
-            if canExpand, !childrenGroups.isEmpty {
+            Section {
                 Button {
-                    self.expandAllSubGroups(group.objectID)
-                } label: {
-                    Label(.localizable(.sidebarGroupRowContextMenuExpandAll), systemSymbol: .squareFillTextGrid1x2)
-                }
-            }
-            
-            if group.groupType != .default {
-                Menu {
-                    if self.group.parent != nil {
-                        Button {
-                            performGroupMoveAction(source: self.group.objectID, target: nil)
-                        } label: {
-                            Text(.localizable(.sidebarGroupRowContextMenuMoveToTopLevel))
-                        }
-                        
-                        Divider()
-                    }
-                    
-                    ForEach(Array(topLevelGroups.filter({$0.groupType != .trash}))) { group in
-                        MoveToGroupMenu(
-                            destination: group,
-                            sourceGroup: self.group,
-                            childrenSortKey: \Group.name,
-                            canMoveToParentGroup: false
-                        ) {
-                            performGroupMoveAction(source: self.group.objectID, target: $0)
-                        }
-                    }
+                    onToogleCreateSubfolder()
                 } label: {
                     Label(
-                        .localizable(.generalMoveTo),
-                        systemSymbol: .trayAndArrowUp
+                        .localizable(.sidebarGroupRowContextMenuAddSubgroup),
+                        systemSymbol: .folderBadgePlus
                     )
+                }
+
+                if let onImportFiles {
+                    Button {
+                        onImportFiles()
+                    } label: {
+                        Label(
+                            .localizable(.menubarButtonImport),
+                            systemSymbol: .squareAndArrowDown
+                        )
+                    }
+                }
+            }
+
+            Section {
+                Button {
+                    onToggleRename()
+                } label: {
+                    if #available(macOS 13.0, *) {
+                        Label(
+                            .localizable(.sidebarGroupRowContextMenuRename),
+                            systemSymbol: .pencilLine
+                        )
+                    } else {
+                        Label(
+                            .localizable(.sidebarGroupRowContextMenuRename),
+                            systemSymbol: .pencil
+                        )
+                    }
+                }
+
+                if canExpand, !childrenGroups.isEmpty {
+                    Button {
+                        self.expandAllSubGroups(group.objectID)
+                    } label: {
+                        Label(
+                            .localizable(.sidebarGroupRowContextMenuExpandAll),
+                            systemSymbol: .squareFillTextGrid1x2
+                        )
+                    }
+                }
+
+                if group.groupType != .default {
+                    Menu {
+                        if self.group.parent != nil {
+                            Button {
+                                performGroupMoveAction(source: self.group.objectID, target: nil)
+                            } label: {
+                                Text(.localizable(.sidebarGroupRowContextMenuMoveToTopLevel))
+                            }
+
+                            Divider()
+                        }
+
+                        ForEach(Array(topLevelGroups.filter({$0.groupType != .trash}))) { group in
+                            MoveToGroupMenu(
+                                destination: group,
+                                sourceGroup: self.group,
+                                childrenSortKey: \Group.name,
+                                canMoveToParentGroup: false
+                            ) {
+                                performGroupMoveAction(source: self.group.objectID, target: $0)
+                            }
+                        }
+                    } label: {
+                        Label(
+                            .localizable(.generalMoveTo),
+                            systemSymbol: .trayAndArrowUp
+                        )
+                    }
                 }
             }
         }
-        
-        SensoryFeedbackButton {
-            try copyEntityURLToClipboard(objectID: group.objectID)
-            alertToast(
-                .init(
-                    displayMode: .hud,
-                    type: .complete(.green),
-                    title: String(localizable: .exportActionCopied)
+
+        Section {
+            SensoryFeedbackButton {
+                try copyEntityURLToClipboard(objectID: group.objectID)
+                alertToast(
+                    .init(
+                        displayMode: .hud,
+                        type: .complete(.green),
+                        title: String(localizable: .exportActionCopied)
+                    )
                 )
-            )
-        } label: {
-            Label(.localizable(.sidebarGroupRowContextMenuCopyGroupLink), systemSymbol: .link)
-        }
-        
-        if group.groupType != .default {
-            Button(role: .destructive) {
-                onToggleDelete()
             } label: {
-                if group.groupType == .trash {
-                    Label(.localizable(.sidebarGroupRowContextMenuEmptyTrash), systemSymbol: .trash)
-                } else {
-                    Label(
-                        .localizable(.sidebarGroupRowContextMenuDelete),
-                        systemSymbol: .trash
-                    )
+                Label(
+                    .localizable(.sidebarGroupRowContextMenuCopyGroupLink),
+                    systemSymbol: .link
+                )
+            }
+        }
+
+        if group.groupType != .default {
+            Section {
+                Button(role: .destructive) {
+                    onToggleDelete()
+                } label: {
+                    if group.groupType == .trash {
+                        Label(
+                            .localizable(.sidebarGroupRowContextMenuEmptyTrash),
+                            systemSymbol: .trash
+                        )
+                    } else {
+                        Label(
+                            .localizable(.sidebarGroupRowContextMenuDelete),
+                            systemSymbol: .trash
+                        )
+                    }
                 }
             }
         }

--- a/ExcalidrawZ/Sidebar/components/SidebarRowModifier.swift
+++ b/ExcalidrawZ/Sidebar/components/SidebarRowModifier.swift
@@ -90,25 +90,21 @@ struct ExcalidrawZSidebarRowModifier: ViewModifier {
 }
 
 
-struct ExcalidrawZSidebarRowButtonStyle: PrimitiveButtonStyle {
+struct ExcalidrawZSidebarRowButtonStyle: ButtonStyle {
     var isSelected: Bool
     var isMultiSelected: Bool
     
     func makeBody(configuration: Configuration) -> some View {
-        PrimitiveButtonWrapper {
-            configuration.trigger()
-        } content: { isPressed in
-            configuration.label
-                .modifier(ExcalidrawZSidebarRowModifier(
-                    isSelected: isSelected,
-                    isMultiSelected: isMultiSelected,
-                    isPressed: isPressed
-                ))
-        }
+        configuration.label
+            .modifier(ExcalidrawZSidebarRowModifier(
+                isSelected: isSelected,
+                isMultiSelected: isMultiSelected,
+                isPressed: configuration.isPressed
+            ))
     }
 }
  
-extension PrimitiveButtonStyle where Self == ExcalidrawZSidebarRowButtonStyle {
+extension ButtonStyle where Self == ExcalidrawZSidebarRowButtonStyle {
     static func excalidrawSidebarRow(
         isSelected: Bool,
         isMultiSelected: Bool

--- a/ExcalidrawZ/Sidebar/components/SidebarSectionAddIcon.swift
+++ b/ExcalidrawZ/Sidebar/components/SidebarSectionAddIcon.swift
@@ -1,0 +1,18 @@
+//
+//  SidebarSectionAddIcon.swift
+//  ExcalidrawZ
+//
+
+import SwiftUI
+
+struct SidebarSectionAddIcon: View {
+    let accessibilityLabel: Text
+
+    var body: some View {
+        Image(systemName: "plus.circle.fill")
+            .font(.callout.weight(.semibold))
+            .tint(.secondary)
+            .frame(width: 18, height: 18)
+            .accessibilityLabel(accessibilityLabel)
+    }
+}

--- a/ExcalidrawZ/Store/FileState+History.swift
+++ b/ExcalidrawZ/Store/FileState+History.swift
@@ -51,14 +51,10 @@ extension FileState {
                 )
 
             case .localFile(let fileURL):
-                guard case .localFolder(let folder) = currentActiveGroup else {
-                    throw AIChatEditError.unsupportedFile
-                }
-
                 let activeFile = ActiveFile.localFile(fileURL)
                 let parsedFile = try ExcalidrawFile(data: content, id: activeFile.id)
 
-                try await folder.withSecurityScopedURL { _ in
+                try await LocalFolder.withSecurityScopedAccessToContainingFolder(for: fileURL) {
                     try await FileCoordinator.shared.coordinatedWrite(url: fileURL, data: content)
                     Self.touchLocalFileModificationDate(fileURL, logger: self.logger)
                 }

--- a/ExcalidrawZ/Store/FileState.swift
+++ b/ExcalidrawZ/Store/FileState.swift
@@ -13,27 +13,10 @@ import UniformTypeIdentifiers
 @preconcurrency import CoreData
 import ChocofordEssentials
 
-
-private final class SecurityScopedResourceLease {
-    let url: URL
-
-    init?(url: URL) {
-        guard url.startAccessingSecurityScopedResource() else { return nil }
-        self.url = url
-    }
-
-    deinit {
-        url.stopAccessingSecurityScopedResource()
-    }
-}
-
 final class FileState: ObservableObject {
     let logger = Logger(label: "FileState")
 
-    // Open-in-place URLs are not backed by a saved LocalFolder bookmark. Keep
-    // their security scope alive for this temporary workspace so asynchronous
-    // canvas reads and writes retain access to the provider-owned document.
-    private var openInPlaceSecurityScopeLeases: [URL: SecurityScopedResourceLease] = [:]
+    private let openInPlaceAccessStore = OpenInPlaceAccessStore()
     
     var stateUpdateQueue: DispatchQueue = DispatchQueue(label: "StateUpdateQueue")
     
@@ -495,7 +478,6 @@ final class FileState: ObservableObject {
             userCheckpointWindowStartedAt.removeValue(forKey: newValue.id)
         }
         resetCurrentFileChangesListener()
-        releaseUnusedOpenInPlaceAccess()
     }
 
     var currentActiveFileIsInTrash: Bool {
@@ -689,6 +671,14 @@ final class FileState: ObservableObject {
         _ file: ActiveFile?,
         generation: Int
     ) async -> Bool {
+        let file = if case .cloudStorageFile(let reference) = file {
+            ActiveFile.cloudStorageFile(
+                CloudStorageDocumentStore.shared.resolvingCurrentIdentity(for: reference)
+            )
+        } else {
+            file
+        }
+
         if aiChatSession != nil, currentActiveFile != file {
             activeFileSwitchBlockedReason = .aiGenerationInProgress
             activeFileSwitchBlockedToken += 1
@@ -775,9 +765,21 @@ final class FileState: ObservableObject {
                     }
 
                     do {
+                        let parentURL = url.deletingLastPathComponent().standardizedFileURL
+                        if case .localFolder(let activeFolder) = currentActiveGroup,
+                           let activeFolderPath = activeFolder.filePath,
+                           URL(fileURLWithPath: activeFolderPath).standardizedFileURL.path
+                            == parentURL.path {
+                            expandToGroup(activeFolder.objectID)
+                            return
+                        }
+
                         let folders = try await context.perform {
                             let fetchRequest = NSFetchRequest<LocalFolder>(entityName: "LocalFolder")
-                            fetchRequest.predicate = NSPredicate(format: "url == %@", url.deletingLastPathComponent() as NSURL)
+                            fetchRequest.predicate = NSPredicate(
+                                format: "filePath == %@",
+                                parentURL.path
+                            )
                             fetchRequest.fetchLimit = 1
                             return try context.fetch(fetchRequest)
                         }
@@ -849,9 +851,7 @@ final class FileState: ObservableObject {
                         return
                     }
 
-                    if !temporaryFiles.contains(where: {$0 == url}) {
-                        temporaryFiles.append(url)
-                    }
+                    registerTemporaryFile(url)
                     setActiveGroupIfNeeded(.temporary)
                 }
             case .collaborationFile(let room):
@@ -949,46 +949,66 @@ final class FileState: ObservableObject {
     
     @Published var temporaryFiles: [URL] = [] {
         didSet {
-            releaseUnusedOpenInPlaceAccess()
+            updateOpenInPlaceOwnership(from: oldValue, to: temporaryFiles)
         }
     }
 
     @MainActor
-    @discardableResult
-    func retainOpenInPlaceAccess(to url: URL) -> Bool {
+    func prepareOpenInPlaceAccess(to url: URL) async throws {
         let key = url.standardizedFileURL
-        if openInPlaceSecurityScopeLeases[key] != nil {
-            return true
+        let wasRegistered = temporaryFiles.contains {
+            $0.standardizedFileURL == key
         }
+        registerTemporaryFile(url)
 
-        guard let lease = SecurityScopedResourceLease(url: url) else {
-            logger.warning("Failed to retain open-in-place access: \(url.lastPathComponent)")
-            return false
+        do {
+            try await openInPlaceAccessStore.prepareAccess(to: url)
+        } catch {
+            if !wasRegistered {
+                temporaryFiles.removeAll { $0.standardizedFileURL == key }
+            }
+            throw error
         }
-
-        openInPlaceSecurityScopeLeases[key] = lease
-        logger.debug("Retained open-in-place access: \(url.lastPathComponent)")
-        return true
     }
 
-    /// Releases provider-owned document access only after the URL has left
-    /// both the temporary workspace and the active editor session. Keeping the
-    /// active URL here is important because closing an editor can flush a final
-    /// write after its Temporary row has already been removed.
-    private func releaseUnusedOpenInPlaceAccess() {
-        var retainedURLs = Set(temporaryFiles.map(\.standardizedFileURL))
-        for activeFile in activeFiles.compactMap({ $0 }) {
-            if case .temporaryFile(let activeURL) = activeFile {
-                retainedURLs.insert(activeURL.standardizedFileURL)
-            }
+    @MainActor
+    func registerTemporaryFile(_ url: URL) {
+        let key = url.standardizedFileURL
+        guard !temporaryFiles.contains(where: { $0.standardizedFileURL == key }) else {
+            return
         }
+        temporaryFiles.append(url)
+    }
 
-        let releasedURLs = openInPlaceSecurityScopeLeases.keys.filter {
-            !retainedURLs.contains($0)
+    @MainActor
+    func readTemporaryFileContent(at url: URL) async throws -> Data {
+        if let content = openInPlaceAccessStore.content(for: url) {
+            return content
         }
-        for url in releasedURLs {
-            openInPlaceSecurityScopeLeases[url] = nil
-            logger.debug("Released open-in-place access: \(url.lastPathComponent)")
+        return try await FileSyncCoordinator.shared.openFileWithActiveSecurityScope(url)
+    }
+
+    /// A directly opened document is owned by its Temporary workspace, not by
+    /// the currently visible editor. Keep its UIDocument session alive while
+    /// the row exists so returning from the editor does not revoke access.
+    private func updateOpenInPlaceOwnership(from oldURLs: [URL], to newURLs: [URL]) {
+        let oldKeys = Set(oldURLs.map(\.standardizedFileURL))
+        let newKeys = Set(newURLs.map(\.standardizedFileURL))
+        let addedKeys = newKeys.subtracting(oldKeys)
+        let removedKeys = oldKeys.subtracting(newKeys)
+
+        guard !addedKeys.isEmpty || !removedKeys.isEmpty else { return }
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let currentKeys = Set(self.temporaryFiles.map(\.standardizedFileURL))
+
+            for url in addedKeys where currentKeys.contains(url) {
+                self.openInPlaceAccessStore.retainAccess(to: url)
+            }
+            for url in removedKeys where !currentKeys.contains(url) {
+                self.openInPlaceAccessStore.releaseAccess(to: url)
+            }
         }
     }
     
@@ -1713,10 +1733,15 @@ final class FileState: ObservableObject {
         var excalidrawFile = excalidrawFile
         try excalidrawFile.updateContentFilesFromFiles()
 
-        // Use FileCoordinator for safe atomic write
         guard let data = excalidrawFile.content else { return }
-        try await FileCoordinator.shared.coordinatedWrite(url: url, data: data)
-        Self.touchLocalFileModificationDate(url, logger: logger)
+        let savedThroughDocumentSession = try await openInPlaceAccessStore.save(data, to: url)
+        if !savedThroughDocumentSession {
+            // Linked Folder files retain a folder-scoped bookmark and continue
+            // to use coordinated URL access. Directly opened iOS documents are
+            // saved by their UIDocument session instead.
+            try await FileCoordinator.shared.coordinatedWrite(url: url, data: data)
+            Self.touchLocalFileModificationDate(url, logger: logger)
+        }
 
         // Skip checkpoint writes entirely while an automated mutation session
         // is active — file content still saves, history doesn't. Mirrors the

--- a/ExcalidrawZ/Store/FileState.swift
+++ b/ExcalidrawZ/Store/FileState.swift
@@ -774,20 +774,16 @@ final class FileState: ObservableObject {
                             return
                         }
 
-                        let folders = try await context.perform {
-                            let fetchRequest = NSFetchRequest<LocalFolder>(entityName: "LocalFolder")
-                            fetchRequest.predicate = NSPredicate(
-                                format: "filePath == %@",
-                                parentURL.path
+                        let folder = try await context.perform {
+                            try LocalFolder.deepestFolder(
+                                containingLocalFileAt: url,
+                                in: context
                             )
-                            fetchRequest.fetchLimit = 1
-                            return try context.fetch(fetchRequest)
                         }
-                        if let folder = folders.first {
+                        if let folder {
                             setActiveGroupIfNeeded(.localFolder(folder))
                             expandToGroup(folder.objectID)
                         } else {
-                            // Handle case where local folder is not found
                             setActiveGroupIfNeeded(nil)
                         }
                     } catch {}

--- a/ExcalidrawZ/Store/ItemDragState.swift
+++ b/ExcalidrawZ/Store/ItemDragState.swift
@@ -93,17 +93,26 @@ struct ItemDropFallbackModifier: ViewModifier {
 
 struct ItemDropGlobalFallbackModifier: ViewModifier {
     @EnvironmentObject private var dragState: ItemDragState
+#if os(macOS)
+    @State private var mouseMovedMonitor: Any?
+#endif
     
     func body(content: Content) -> some View {
         content
 #if os(macOS)
             .onAppear {
-                NSEvent.addLocalMonitorForEvents(matching: .mouseMoved) { event in
+                guard mouseMovedMonitor == nil else { return }
+                mouseMovedMonitor = NSEvent.addLocalMonitorForEvents(matching: .mouseMoved) { event in
                     if dragState.hasAnyDragState {
                         dragState.reset()
                     }
                     return event
                 }
+            }
+            .onDisappear {
+                guard let mouseMovedMonitor else { return }
+                NSEvent.removeMonitor(mouseMovedMonitor)
+                self.mouseMovedMonitor = nil
             }
 #endif // os(macOS)
     }

--- a/ExcalidrawZ/Utils/FileSyncCoordinator/FileSyncCoordinator.swift
+++ b/ExcalidrawZ/Utils/FileSyncCoordinator/FileSyncCoordinator.swift
@@ -57,7 +57,11 @@ actor FileSyncCoordinator {
     ///   - url: The folder URL to monitor
     ///   - options: Configuration options
     /// - Throws: FolderError if folder is invalid or inaccessible
-    func addFolder(at url: URL, options: FolderSyncOptions) async throws {
+    func addFolder(
+        at url: URL,
+        options: FolderSyncOptions,
+        securityScopeBookmarkData: Data? = nil
+    ) async throws {
         // Validate URL
         guard url.isFileURL else {
             throw FolderError.invalidFolder
@@ -78,6 +82,7 @@ actor FileSyncCoordinator {
         // Create and start monitor
         let monitor = FolderMonitor(
             folderURL: url,
+            securityScopeBookmarkData: securityScopeBookmarkData,
             options: options,
             onFileEvent: { [weak self] event in
                 await self?.handleFileEvent(event)
@@ -222,11 +227,26 @@ actor FileSyncCoordinator {
     /// - Returns: File data
     /// - Throws: FileCoordinatorError if unable to open file
     func openFile(_ url: URL) async throws -> Data {
-        let fileCoordinator = self.fileCoordinator
         return try await LocalFolder.withSecurityScopedAccessToContainingFolder(for: url) {
-            try await fileCoordinator.coordinatedRead(url: url) { coordinatedURL in
-                try Data(contentsOf: coordinatedURL)
-            }
+            try await self.openAccessibleFile(url)
+        }
+    }
+
+    /// Opens a URL whose file-scoped security grant is already retained by
+    /// the caller, such as a document delivered through SwiftUI `onOpenURL`.
+    /// Do not resolve a containing Linked Folder bookmark for these files: it
+    /// may be stale and is unrelated to the direct grant.
+    func openFileWithActiveSecurityScope(_ url: URL) async throws -> Data {
+        try await openAccessibleFile(url)
+    }
+
+    private func openAccessibleFile(_ url: URL) async throws -> Data {
+        if let status = try? await ICloudStatusChecker.shared.checkStatus(for: url),
+           status == .notDownloaded || status == .outdated || status.isInProgress {
+            try await fileCoordinator.downloadFile(url: url)
+        }
+        return try await fileCoordinator.coordinatedRead(url: url) { coordinatedURL in
+            try Data(contentsOf: coordinatedURL)
         }
     }
 

--- a/ExcalidrawZ/Utils/FileSyncCoordinator/FolderMonitor.swift
+++ b/ExcalidrawZ/Utils/FileSyncCoordinator/FolderMonitor.swift
@@ -26,6 +26,7 @@ actor FolderMonitor {
     private let logger = Logger(label: "FolderMonitor")
 
     let folderURL: URL
+    private let securityScopeBookmarkData: Data?
     let options: FolderSyncOptions
     let onFileEvent: (FileEvent) async -> Void
 
@@ -42,10 +43,12 @@ actor FolderMonitor {
 
     init(
         folderURL: URL,
+        securityScopeBookmarkData: Data? = nil,
         options: FolderSyncOptions,
         onFileEvent: @escaping (FileEvent) async -> Void
     ) {
         self.folderURL = folderURL
+        self.securityScopeBookmarkData = securityScopeBookmarkData
         self.options = options
         self.onFileEvent = onFileEvent
     }
@@ -111,6 +114,7 @@ actor FolderMonitor {
         #elseif os(iOS)
         fileSystemMonitor = IOSFileSystemMonitor(
             folderURL: folderURL,
+            securityScopeBookmarkData: securityScopeBookmarkData,
             options: options,
             onEvent: { [weak self] event in
                 await self?.onFileEvent(event)
@@ -279,6 +283,7 @@ actor IOSFileSystemMonitor: NSObject, FileSystemMonitorProtocol, NSFilePresenter
     private let logger = Logger(label: "IOSFileSystemMonitor")
 
     private let folderURL: URL
+    private let securityScopeBookmarkData: Data?
     private let options: FolderSyncOptions
     private let onEvent: (FileEvent) async -> Void
 
@@ -287,13 +292,16 @@ actor IOSFileSystemMonitor: NSObject, FileSystemMonitorProtocol, NSFilePresenter
     nonisolated var presentedItemOperationQueue: OperationQueue { OperationQueue.main }
 
     private var isActive = false
+    private var securityScopedURL: URL?
 
     init(
         folderURL: URL,
+        securityScopeBookmarkData: Data?,
         options: FolderSyncOptions,
         onEvent: @escaping (FileEvent) async -> Void
     ) {
         self.folderURL = folderURL
+        self.securityScopeBookmarkData = securityScopeBookmarkData
         self.options = options
         self.onEvent = onEvent
         super.init()
@@ -302,8 +310,21 @@ actor IOSFileSystemMonitor: NSObject, FileSystemMonitorProtocol, NSFilePresenter
     func start() async throws {
         guard !isActive else { return }
 
-        guard folderURL.startAccessingSecurityScopedResource() else {
-            throw SecurityScopeError()
+        if let securityScopeBookmarkData {
+            var isStale = false
+            // Resolving a document-picker bookmark on iOS implicitly starts
+            // security-scoped access. Retain that resolved URL for the entire
+            // lifetime of the file presenter and balance it in stop().
+            securityScopedURL = try URL(
+                resolvingBookmarkData: securityScopeBookmarkData,
+                options: [],
+                bookmarkDataIsStale: &isStale
+            )
+        } else {
+            guard folderURL.startAccessingSecurityScopedResource() else {
+                throw SecurityScopeError()
+            }
+            securityScopedURL = folderURL
         }
 
         // Register as file presenter
@@ -315,7 +336,8 @@ actor IOSFileSystemMonitor: NSObject, FileSystemMonitorProtocol, NSFilePresenter
         guard isActive else { return }
 
         NSFileCoordinator.removeFilePresenter(self)
-        folderURL.stopAccessingSecurityScopedResource()
+        securityScopedURL?.stopAccessingSecurityScopedResource()
+        securityScopedURL = nil
         isActive = false
     }
 

--- a/ExcalidrawZ/Utils/FileSyncCoordinator/OpenInPlaceDocumentSession.swift
+++ b/ExcalidrawZ/Utils/FileSyncCoordinator/OpenInPlaceDocumentSession.swift
@@ -1,0 +1,205 @@
+import Foundation
+#if os(iOS)
+import UIKit
+#endif
+import Logging
+
+/// Owns the platform-specific access lifetime for documents opened in place.
+/// FileState supplies the URLs still owned by workspaces and editor sessions;
+/// this store handles document sessions, security-scope leases, and cleanup.
+final class OpenInPlaceAccessStore {
+    private let logger = Logger(label: "OpenInPlaceAccessStore")
+    private var closeTasks: [URL: Task<Void, Never>] = [:]
+    private var retainedURLs: Set<URL> = []
+
+#if os(iOS)
+    private var sessions: [URL: OpenInPlaceDocumentSession] = [:]
+#else
+    private var leases: [URL: SecurityScopedResourceLease] = [:]
+#endif
+
+    @MainActor
+    func prepareAccess(to url: URL) async throws {
+        let key = url.standardizedFileURL
+        retainAccess(to: key)
+#if os(iOS)
+        guard sessions[key] == nil else { return }
+
+        do {
+            sessions[key] = try await OpenInPlaceDocumentSession.open(url: url)
+        } catch {
+            retainedURLs.remove(key)
+            throw error
+        }
+        logger.debug("Opened external document session: \(url.lastPathComponent)")
+#else
+        guard leases[key] == nil else { return }
+        guard let lease = SecurityScopedResourceLease(url: url) else {
+            retainedURLs.remove(key)
+            logger.warning("Failed to retain open-in-place access: \(url.lastPathComponent)")
+            throw AppError.urlError(.startAccessingSecurityScopedResourceFailed)
+        }
+        leases[key] = lease
+        logger.debug("Retained open-in-place access: \(url.lastPathComponent)")
+#endif
+    }
+
+    @MainActor
+    func retainAccess(to url: URL) {
+        let key = url.standardizedFileURL
+        retainedURLs.insert(key)
+        if let closeTask = closeTasks.removeValue(forKey: key) {
+            closeTask.cancel()
+            logger.debug("Cancelled open-in-place access release: \(key.lastPathComponent)")
+        }
+    }
+
+    @MainActor
+    func content(for url: URL) -> Data? {
+#if os(iOS)
+        sessions[url.standardizedFileURL]?.content
+#else
+        nil
+#endif
+    }
+
+    @MainActor
+    func save(_ content: Data, to url: URL) async throws -> Bool {
+#if os(iOS)
+        guard let session = sessions[url.standardizedFileURL] else { return false }
+        try await session.save(content: content)
+        return true
+#else
+        return false
+#endif
+    }
+
+    @MainActor
+    func releaseAccess(to url: URL) {
+        let key = url.standardizedFileURL
+#if os(iOS)
+        retainedURLs.remove(key)
+        guard sessions[key] != nil, closeTasks[key] == nil else { return }
+        logger.debug("Scheduled external document session close: \(key.lastPathComponent)")
+        closeTasks[key] = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            guard !Task.isCancelled, let self else { return }
+
+            self.closeTasks[key] = nil
+            guard !self.retainedURLs.contains(key),
+                  let session = self.sessions.removeValue(forKey: key) else {
+                return
+            }
+            await session.close()
+            self.logger.debug("Closed external document session: \(key.lastPathComponent)")
+        }
+#else
+        retainedURLs.remove(key)
+        guard leases[key] != nil, closeTasks[key] == nil else { return }
+        logger.debug("Scheduled open-in-place access release: \(key.lastPathComponent)")
+        closeTasks[key] = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            guard !Task.isCancelled, let self else { return }
+
+            self.closeTasks[key] = nil
+            guard !self.retainedURLs.contains(key) else { return }
+            self.leases[key] = nil
+            self.logger.debug("Released open-in-place access: \(key.lastPathComponent)")
+        }
+#endif
+    }
+}
+
+#if os(iOS)
+
+/// Keeps an external document open for the lifetime of a Temporary workspace.
+/// `UIDocument` owns the security-scoped URL and acts as its file presenter.
+@MainActor
+final class OpenInPlaceDocumentSession {
+    let url: URL
+
+    private let document: OpenInPlaceDataDocument
+
+    private init(url: URL, document: OpenInPlaceDataDocument) {
+        self.url = url
+        self.document = document
+    }
+
+    static func open(url: URL) async throws -> OpenInPlaceDocumentSession {
+        let document = OpenInPlaceDataDocument(fileURL: url)
+        let didOpen = await withCheckedContinuation { continuation in
+            document.open { success in
+                continuation.resume(returning: success)
+            }
+        }
+
+        guard didOpen else {
+            throw CocoaError(.fileReadNoPermission, userInfo: [NSURLErrorKey: url])
+        }
+
+        return OpenInPlaceDocumentSession(url: url, document: document)
+    }
+
+    var content: Data {
+        document.content
+    }
+
+    func save(content: Data) async throws {
+        document.replaceContent(with: content)
+        let didSave = await withCheckedContinuation { continuation in
+            document.save(to: url, for: .forOverwriting) { success in
+                continuation.resume(returning: success)
+            }
+        }
+        guard didSave else {
+            throw CocoaError(.fileWriteUnknown, userInfo: [NSURLErrorKey: url])
+        }
+    }
+
+    func close() async {
+        guard document.documentState.contains(.closed) == false else { return }
+        await withCheckedContinuation { continuation in
+            document.close { _ in
+                continuation.resume()
+            }
+        }
+    }
+}
+
+private final class OpenInPlaceDataDocument: UIDocument {
+    private(set) var content = Data()
+
+    func replaceContent(with content: Data) {
+        self.content = content
+        updateChangeCount(.done)
+    }
+
+    override func load(fromContents contents: Any, ofType typeName: String?) throws {
+        if let data = contents as? Data {
+            content = data
+        } else if let fileWrapper = contents as? FileWrapper,
+                  let data = fileWrapper.regularFileContents {
+            content = data
+        } else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+    }
+
+    override func contents(forType typeName: String) throws -> Any {
+        content
+    }
+}
+#else
+private final class SecurityScopedResourceLease {
+    let url: URL
+
+    init?(url: URL) {
+        guard url.startAccessingSecurityScopedResource() else { return nil }
+        self.url = url
+    }
+
+    deinit {
+        url.stopAccessingSecurityScopedResource()
+    }
+}
+#endif

--- a/ExcalidrawZ/components/ImportFilesModifier.swift
+++ b/ExcalidrawZ/components/ImportFilesModifier.swift
@@ -1,0 +1,31 @@
+//
+//  ImportFilesModifier.swift
+//  ExcalidrawZ
+//
+
+import SwiftUI
+
+struct ImportFilesModifier: ViewModifier {
+    @Binding var isPresented: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .fileImporterWithAlert(
+                isPresented: $isPresented,
+                allowedContentTypes: [
+                    .init(filenameExtension: "excalidraw") ?? .excalidrawFile,
+                    .excalidrawPNG,
+                    .excalidrawSVG,
+                    .png,
+                    .svg,
+                    .folder
+                ],
+                allowsMultipleSelection: true
+            ) { urls in
+                NotificationCenter.default.post(
+                    name: .shouldHandleImport,
+                    object: urls
+                )
+            }
+    }
+}

--- a/ExcalidrawZ/components/NewFileButton.swift
+++ b/ExcalidrawZ/components/NewFileButton.swift
@@ -20,8 +20,6 @@ struct NewFileButton: View {
     @Environment(\.managedObjectContext) private var viewContext
     @Environment(\.alertToast) private var alertToast
     @Environment(\.alert) private var alert
-    @Environment(\.containerHorizontalSizeClass) var containerHorizontalSizeClass
-
     @EnvironmentObject private var store: Store
     @EnvironmentObject private var fileState: FileState
     @EnvironmentObject private var collaborationState: CollaborationState
@@ -44,52 +42,15 @@ struct NewFileButton: View {
     @State private var window: UIWindow?
 #endif
     
-    @State private var isFileImporterPresented = false
-    
     @FetchRequest(sortDescriptors: [])
     private var collaborationFiles: FetchedResults<CollaborationFile>
     
     var body: some View {
-#if os(iOS)
-        if canShowImportButton, containerHorizontalSizeClass != .compact {
-            Button {
-                isFileImporterPresented.toggle()
-            } label: {
-                Label(.localizable(.menubarButtonImport), systemSymbol: .squareAndArrowDown)
-            }
-            .fileImporter(
-                isPresented: $isFileImporterPresented,
-                allowedContentTypes: [.excalidrawFile],
-                allowsMultipleSelection: true
-            ) { result in
-                if case .success(let urls) = result {
-                    // Should hanlde here...
-                    Task.detached {
-                        do {
-                            try await fileState.importFiles(urls)
-                        } catch {
-                            await alertToast(error)
-                        }
-                    }
-                } else if case .failure(let error) = result {
-                    alertToast(error)
-                }
-            }
-        }
-#endif
-        
         if fileState.isInCollaborationSpace {
             collaborationNewButton()
         } else {
             localNewButton()
         }
-    }
-    
-    private var canShowImportButton: Bool {
-        guard case .group(let group) = fileState.currentActiveGroup else {
-            return false
-        }
-        return group.groupType != .trash
     }
 
     @ViewBuilder

--- a/ExcalidrawZ/components/NewFileButton.swift
+++ b/ExcalidrawZ/components/NewFileButton.swift
@@ -210,7 +210,6 @@ struct NewFileButton: View {
                             }
                             await MainActor.run {
                                 localFolderState.itemCreatedPublisher.send(url.filePath)
-
                                 if usesFileHomeOpenTransition {
                                     fileState.setActiveFile(.localFile(url))
                                 }

--- a/ExcalidrawZ/components/NewGroupButton.swift
+++ b/ExcalidrawZ/components/NewGroupButton.swift
@@ -15,6 +15,7 @@ struct NewGroupButton: View {
     @Environment(\.alertToast) private var alertToast
     @EnvironmentObject private var fileState: FileState
     @ObservedObject private var cloudStorageDocumentStore = CloudStorageDocumentStore.shared
+    @ObservedObject private var cloudStorageConnections = CloudStorageConnectionStore.shared
 
     enum GroupType {
         case localFolder
@@ -123,37 +124,38 @@ struct NewGroupButton: View {
                     label(.localFolder)
                 }
             case .cloudStorageFolder:
-                Button {
-                    guard !isCreatingCloudFolder else { return }
-                    guard let folder = activeCloudStorageParent else { return }
-                    newCloudFolderName = CloudStorageDocumentStore.shared.availableFolderName(
-                        in: folder
-                    )
-                    isCreateCloudFolderDialogPresented = true
-                } label: {
-                    ZStack {
-                        label(.cloudStorageFolder)
-                            .opacity(isCreatingCloudFolder ? 0 : 1)
+                if canCreateFolderInActiveCloudFolder {
+                    Button {
+                        guard !isCreatingCloudFolder else { return }
+                        guard let folder = activeCloudStorageParent else { return }
+                        newCloudFolderName = CloudStorageDocumentStore.shared.availableFolderName(
+                            in: folder
+                        )
+                        isCreateCloudFolderDialogPresented = true
+                    } label: {
+                        ZStack {
+                            label(.cloudStorageFolder)
+                                .opacity(isCreatingCloudFolder ? 0 : 1)
 
-                        if isCreatingCloudFolder {
-                            ProgressView()
-                                .controlSize(.small)
+                            if isCreatingCloudFolder {
+                                ProgressView()
+                                    .controlSize(.small)
+                            }
                         }
                     }
+                    .disabled(isCreatingCloudFolder)
                 }
-                .disabled(
-                    isCreatingCloudFolder
-                        || !canCreateChildrenInActiveCloudFolder
-                )
             default:
                 EmptyView()
         }
     }
 
-    private var canCreateChildrenInActiveCloudFolder: Bool {
+    private var canCreateFolderInActiveCloudFolder: Bool {
         guard let folder = activeCloudStorageParent else { return false }
-        return cloudStorageDocumentStore.capabilities(for: folder)
-            .contains(.createChildren)
+        return cloudStorageDocumentStore.canCreateFolder(
+            in: folder,
+            connections: cloudStorageConnections
+        )
     }
 
     private var activeCloudStorageParent: CloudStorageFolderReference? {

--- a/ExcalidrawZ/components/WhatsNew/WhatsNewSheetView+allFeatures.swift
+++ b/ExcalidrawZ/components/WhatsNew/WhatsNewSheetView+allFeatures.swift
@@ -9,6 +9,7 @@
 //  2. Move the previous featuresContent() rows into allFeaturesList() as a
 //     dedicated WhatsNewVersionSection.
 //  3. Keep version sections flat; do not extract per-version helper views.
+//  4. Do not archive rows marked as a current-release recap.
 //
 
 import SwiftUI
@@ -17,57 +18,23 @@ import SFSafeSymbols
 extension WhatsNewView {
     @ViewBuilder
     func featuresContent() -> some View {
-        WhatsNewFeatureRow {
-            CloudStorageProviderIcon(providerID: .microsoftOneDrive, size: 40)
-        } content: {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(verbatim: "OneDrive")
-                    .font(.headline)
-                Text(.localizable(.whatsNewOneDriveDescription))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
+        WhatsNewFeatureRow(
+            title: .localizable(.whatsNewNativeColorPickerTitle),
+            description: .localizable(.whatsNewNativeColorPickerDescription),
+        ) {
+            Image(systemName: "eyedropper")
+                .resizable()
+                .symbolRenderingMode(.hierarchical)
         }
 
-        WhatsNewFeatureRow {
-            CloudStorageProviderIcon(providerID: .dropbox, size: 40)
-        } content: {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(verbatim: "Dropbox")
-                    .font(.headline)
-                Text(.localizable(.whatsNewDropboxDescription))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-        }
-
-        WhatsNewFeatureRow {
-            CloudStorageProviderIcon(providerID: .googleDrive, size: 40)
-        } content: {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(verbatim: "Google Drive")
-                    .font(.headline)
-                Text(.localizable(.whatsNewGoogleDriveDescription))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-        }
-
-        WhatsNewFeatureRow {
-            CloudStorageProviderIcon(providerID: .webDAV, size: 40)
-        } content: {
-            VStack(alignment: .leading, spacing: 4) {
-                HStack(spacing: 6) {
-                    Text(verbatim: "WebDAV")
-                        .font(.headline)
-                    Text(.localizable(.generalBadgeBeta))
-                        .font(.caption2.bold())
-                        .foregroundStyle(.orange)
-                }
-                Text(.localizable(.whatsNewWebDAVDescription))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
+        // Recaps the 2.4.0 release for current users; do not archive with 2.4.1.
+        WhatsNewFeatureRow(
+            title: .localizable(.whatsNewCloudStorageTitle),
+            description: .localizable(.whatsNewCloudStorageDescription),
+        ) {
+            Image(systemName: "externaldrive.connected.to.line.below")
+                .resizable()
+                .symbolRenderingMode(.hierarchical)
         }
     }
 
@@ -80,6 +47,48 @@ extension WhatsNewView {
                         version: Bundle.main.infoDictionary!["CFBundleShortVersionString"] as! String
                     ) {
                         featuresContent()
+                    }
+                    WhatsNewVersionSection(version: "v2.4.0") {
+                        WhatsNewFeatureRow {
+                            CloudStorageProviderIcon(providerID: .microsoftOneDrive, size: 40)
+                        } content: {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(verbatim: "OneDrive")
+                                    .font(.headline)
+                                Text(.localizable(.whatsNewOneDriveDescription))
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+
+                        WhatsNewFeatureRow {
+                            CloudStorageProviderIcon(providerID: .dropbox, size: 40)
+                        } content: {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(verbatim: "Dropbox")
+                                    .font(.headline)
+                                Text(.localizable(.whatsNewDropboxDescription))
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+
+                        WhatsNewFeatureRow {
+                            CloudStorageProviderIcon(providerID: .webDAV, size: 40)
+                        } content: {
+                            VStack(alignment: .leading, spacing: 4) {
+                                HStack(spacing: 6) {
+                                    Text(verbatim: "WebDAV")
+                                        .font(.headline)
+                                    Text(.localizable(.generalBadgeBeta))
+                                        .font(.caption2.bold())
+                                        .foregroundStyle(.orange)
+                                }
+                                Text(.localizable(.whatsNewWebDAVDescription))
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
                     }
                     WhatsNewVersionSection(version: "v2.3.0") {
                         WhatsNewFeatureRow(

--- a/ExcalidrawZRelease.command
+++ b/ExcalidrawZRelease.command
@@ -12,6 +12,7 @@ fi
 
 PBX_PATH="ExcalidrawZ.xcodeproj/project.pbxproj"
 RELEASE_VERSION=""
+RELEASE_TAG=""
 PREVIEW_DEVICE=""
 PREVIEW_LOCALES=""
 UPLOAD_PROXY_PORT=""
@@ -201,6 +202,25 @@ read_release_version() {
   RELEASE_VERSION="$version"
 }
 
+read_release_tag() {
+  local default_tag="v$RELEASE_VERSION"
+  local tag
+
+  read "?GitHub Release tag [$default_tag]: " tag
+  if [[ -z "$tag" ]]; then
+    tag="$default_tag"
+  elif [[ "$tag" != v* ]]; then
+    tag="v$tag"
+  fi
+
+  if [[ ! "$tag" =~ '^v[A-Za-z0-9][A-Za-z0-9._-]*$' ]]; then
+    echo "GitHub Release tag 格式不正确，需要类似 v2.4.1 或 v2.4.1A"
+    return 1
+  fi
+
+  RELEASE_TAG="$tag"
+}
+
 read_upload_proxy_port() {
   local port
 
@@ -376,7 +396,12 @@ prepare_sparkle_release() {
   local -a args
 
   read_release_version || return 1
-  args=(mac prepare_sparkle_release "version:$RELEASE_VERSION")
+  read_release_tag || return 1
+  args=(
+    mac prepare_sparkle_release
+    "version:$RELEASE_VERSION"
+    "release_tag:$RELEASE_TAG"
+  )
   if [[ "$verify_asset" == "true" ]]; then
     args+=("verify_asset:true")
   fi

--- a/ExcalidrawZTests/GoogleDriveModelsTests.swift
+++ b/ExcalidrawZTests/GoogleDriveModelsTests.swift
@@ -7,10 +7,10 @@ import XCTest
 @testable import ExcalidrawZ
 
 final class GoogleDriveModelsTests: XCTestCase {
-    func testUsesFullDriveScopeForFolderConnections() {
+    func testUsesPerFileDriveScope() {
         XCTAssertEqual(
             GoogleDriveConfiguration.driveScope,
-            "https://www.googleapis.com/auth/drive"
+            "https://www.googleapis.com/auth/drive.file"
         )
     }
 
@@ -26,6 +26,34 @@ final class GoogleDriveModelsTests: XCTestCase {
         let credential = try JSONDecoder().decode(GoogleDriveCredential.self, from: data)
 
         XCTAssertFalse(credential.hasRequiredScope)
+    }
+
+    func testFullDriveCredentialRequiresScopeReplacement() {
+        let credential = GoogleDriveCredential(
+            accountID: "account-1",
+            displayName: "Example",
+            emailAddress: nil,
+            accessToken: "access-token",
+            refreshToken: "refresh-token",
+            expiresAt: .distantFuture,
+            grantedScopes: ["https://www.googleapis.com/auth/drive"]
+        )
+
+        XCTAssertFalse(credential.hasRequiredScope)
+    }
+
+    func testDriveFileCredentialHasRequiredScope() {
+        let credential = GoogleDriveCredential(
+            accountID: "account-1",
+            displayName: "Example",
+            emailAddress: nil,
+            accessToken: "access-token",
+            refreshToken: "refresh-token",
+            expiresAt: .distantFuture,
+            grantedScopes: [GoogleDriveConfiguration.driveScope]
+        )
+
+        XCTAssertTrue(credential.hasRequiredScope)
     }
 
     func testUsesReverseClientIDCallbackConvention() {
@@ -59,10 +87,10 @@ final class GoogleDriveModelsTests: XCTestCase {
               "capabilities": {
                 "canDownload": true,
                 "canAddChildren": false,
-                "canEdit": true,
+                "canModifyContent": true,
                 "canRename": true,
                 "canMoveItemWithinDrive": true,
-                "canDelete": true
+                "canTrash": true
               },
               "trashed": false
             }
@@ -91,10 +119,10 @@ final class GoogleDriveModelsTests: XCTestCase {
               "capabilities": {
                 "canDownload": true,
                 "canAddChildren": true,
-                "canEdit": true,
+                "canModifyContent": true,
                 "canRename": true,
                 "canMoveItemWithinDrive": true,
-                "canDelete": true
+                "canTrash": true
               },
               "trashed": false
             }
@@ -107,6 +135,31 @@ final class GoogleDriveModelsTests: XCTestCase {
         XCTAssertEqual(item.kind, .folder)
         XCTAssertFalse(item.effectiveCapabilities.contains(.download))
         XCTAssertTrue(item.effectiveCapabilities.contains(.createChildren))
+    }
+
+    func testMapsCapabilitiesToTheOperationsActuallyUsedByTheClient() throws {
+        let data = Data(
+            """
+            {
+              "id": "file-1",
+              "name": "Drawing.excalidraw",
+              "mimeType": "application/octet-stream",
+              "capabilities": {
+                "canEdit": true,
+                "canModifyContent": false,
+                "canDelete": true,
+                "canTrash": false
+              },
+              "trashed": false
+            }
+            """.utf8
+        )
+
+        let file = try JSONDecoder.googleDriveDecoder().decode(GoogleDriveFile.self, from: data)
+        let capabilities = file.cloudStorageItem.effectiveCapabilities
+
+        XCTAssertFalse(capabilities.contains(.updateContent))
+        XCTAssertFalse(capabilities.contains(.delete))
     }
 
     func testContentChecksumTakesPriorityOverMetadataVersion() throws {


### PR DESCRIPTION
### Bug fixed

- Fixed remaining permission errors when opening external drawings from Files, reopening them from Temporary, or accessing Linked Folders on iPhone and iPad.
- Fixed Linked Folders on iPhone and iPad failing to refresh while File Provider content was still downloading, with clearer availability feedback.
- Fixed collaboration rooms on iPhone and iPad occasionally remaining stuck on the loading screen.
- Fixed Linked Folder drawings sometimes losing their containing folder context, which could affect sharing and return navigation.
- Fixed iPad Sidebar scrolling not responding when a gesture started over a folder row.
- Fixed iPad file transitions using a matching item from an inactive tab.
- Fixed a macOS drag-and-drop event monitor remaining registered after its view disappeared.

### Optimizations

- Refined File Home and group menus on Mac and iPad, including group-specific imports and consistent Sidebar section controls.